### PR TITLE
Milestone-1 CLI prototype

### DIFF
--- a/src/complex_editor/cli.py
+++ b/src/complex_editor/cli.py
@@ -1,9 +1,54 @@
-"""CLI entry points for Complex‑Editor."""
-import argparse, sys
-def main():
-    parser = argparse.ArgumentParser(description="Complex‑Editor CLI")
+"""CLI entry points for Complex-Editor."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .db import connect, fetch_comp_desc_rows, table_exists
+from .db.schema_introspect import discover_macro_map
+
+
+def list_complexes_cmd(args: argparse.Namespace) -> int:
+    conn = connect(args.mdb_path)
+    cursor = conn.cursor()
+    if not table_exists(cursor, "tabCompDesc"):
+        print("Error: table tabCompDesc not found in MDB.")
+        return 1
+    macro_map = discover_macro_map(cursor)
+    rows = fetch_comp_desc_rows(cursor, args.limit)
+    for row in rows:
+        id_comp = getattr(row, "IDCompDesc", row[0])
+        id_func = getattr(row, "IDFunction", row[1])
+        macro = macro_map.get(int(id_func), f"ID {id_func}")
+        pin_a = getattr(row, "PinA", row[2])
+        pin_b = getattr(row, "PinB", row[3])
+        pin_c = getattr(row, "PinC", row[4])
+        pin_d = getattr(row, "PinD", row[5])
+        pin_s = getattr(row, "PinS", row[6])
+        print(
+            f"{id_comp}\t{macro}\t{pin_a}\t{pin_b}\t{pin_c}\t{pin_d}\t"
+            f"{'yes' if pin_s else 'no'}"
+        )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Complex-Editor CLI")
     parser.add_argument("--version", action="version", version="0.0.1")
-    args = parser.parse_args()
-    print("Complex‑Editor CLI – nothing here yet")
+    sub = parser.add_subparsers(dest="command", required=True)
+    list_p = sub.add_parser("list-complexes", help="List complexes from MDB")
+    list_p.add_argument("mdb_path")
+    list_p.add_argument("--limit", type=int, default=10)
+    list_p.set_defaults(func=list_complexes_cmd)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/complex_editor/db/__init__.py
+++ b/src/complex_editor/db/__init__.py
@@ -1,1 +1,5 @@
-# db subpackage
+"""Database access helpers for Complex-Editor."""
+
+from .access_driver import connect, fetch_comp_desc_rows, fetch_macro_pairs, table_exists
+
+__all__ = ["connect", "fetch_comp_desc_rows", "fetch_macro_pairs", "table_exists"]

--- a/src/complex_editor/db/access_driver.py
+++ b/src/complex_editor/db/access_driver.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pyodbc
+
+
+def connect(mdb_path: str) -> pyodbc.Connection:
+    """Return pyodbc connection to the given MDB path."""
+    conn_str = (
+        "Driver={Microsoft Access Driver (*.mdb, *.accdb)};"
+        f"DBQ={mdb_path};"
+    )
+    return pyodbc.connect(conn_str, autocommit=True)
+
+
+def table_exists(cursor: pyodbc.Cursor, table: str) -> bool:
+    """Return True if the table exists in the MDB."""
+    for row in cursor.tables(table=table, tableType="TABLE"):
+        if row.table_name.lower() == table.lower():
+            return True
+    return False
+
+
+def fetch_comp_desc_rows(cursor: pyodbc.Cursor, limit: int):
+    """Fetch rows from tabCompDesc limited by ``limit``."""
+    query = (
+        f"SELECT TOP {limit} "
+        "IDCompDesc, IDFunction, PinA, PinB, PinC, PinD, PinS "
+        "FROM tabCompDesc"
+    )
+    return cursor.execute(query).fetchall()
+
+
+def fetch_macro_pairs(cursor: pyodbc.Cursor, table: str, macro_col: str):
+    """Return (IDFunction, macro_name) pairs from the given table."""
+    query = f"SELECT IDFunction, [{macro_col}] FROM [{table}]"
+    return cursor.execute(query).fetchall()

--- a/src/complex_editor/db/schema_introspect.py
+++ b/src/complex_editor/db/schema_introspect.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .access_driver import fetch_macro_pairs
+
+
+CANDIDATE_MACRO_COLS = ["MacroName", "FunctionName", "Macro", "Function"]
+
+
+def discover_macro_map(cursor) -> Dict[int, str]:
+    """Discover mapping from IDFunction to macro name using MDB schema."""
+    macro_map: Dict[int, str] = {}
+    for t in cursor.tables(tableType="TABLE"):
+        table = t.table_name
+        columns = [c.column_name for c in cursor.columns(table=table)]
+        if "IDFunction" not in columns:
+            continue
+        macro_col = next((c for c in CANDIDATE_MACRO_COLS if c in columns), None)
+        if not macro_col:
+            continue
+        for id_function, name in fetch_macro_pairs(cursor, table, macro_col):
+            if id_function is None or name is None:
+                continue
+            macro_map[int(id_function)] = str(name)
+    return macro_map

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import types
+
+import os
+import sys
+import types as py_types
+
+# Provide a dummy pyodbc module so import succeeds
+sys.modules.setdefault("pyodbc", py_types.ModuleType("pyodbc"))
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+from complex_editor import cli  # noqa: E402
+from complex_editor.db import access_driver  # noqa: E402
+
+
+class FakeCursor:
+    def tables(self, table=None, tableType=None):
+        if table is not None:
+            if table == "tabCompDesc":
+                yield types.SimpleNamespace(table_name="tabCompDesc")
+            return
+        yield types.SimpleNamespace(table_name="tabCompDesc")
+        yield types.SimpleNamespace(table_name="tabFunction")
+
+    def columns(self, table):
+        if table == "tabCompDesc":
+            cols = [
+                "IDCompDesc",
+                "IDFunction",
+                "PinA",
+                "PinB",
+                "PinC",
+                "PinD",
+                "PinS",
+            ]
+        else:
+            cols = ["IDFunction", "MacroName"]
+        for c in cols:
+            yield types.SimpleNamespace(column_name=c)
+
+    def execute(self, query):
+        self.last_query = query
+        return self
+
+    def fetchall(self):
+        if "tabFunction" in self.last_query:
+            return [(1, "MACRO1"), (2, "MACRO2")]
+        return [
+            (1, 1, "A1", "B1", "C1", "D1", "<xml>"),
+            (2, 3, "A2", "B2", "C2", "D2", None),
+        ]
+
+    def fetchmany(self, num):
+        return self.fetchall()[:num]
+
+
+class FakeConnection:
+    def cursor(self):
+        return FakeCursor()
+
+
+def fake_connect(path):
+    return FakeConnection()
+
+
+def test_list_complexes(monkeypatch, capsys):
+    monkeypatch.setattr(access_driver, "connect", fake_connect)
+    monkeypatch.setattr(cli, "connect", fake_connect)
+    exit_code = cli.main(["list-complexes", "dummy.mdb", "--limit", "1"])
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert "MACRO1" in out


### PR DESCRIPTION
## Summary
- implement `access_driver` for DB connectivity and queries
- add schema introspection to build a macro lookup map
- extend CLI with `list-complexes` subcommand
- add test covering CLI behavior with mocked DB

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686284f7aa7c832ca38b1b4b3d658213