### PR TITLE
Add PinS XML serialization and dataclasses

### DIFF
--- a/src/complex_editor/domain/__init__.py
+++ b/src/complex_editor/domain/__init__.py
@@ -1,6 +1,18 @@
 """Domain models."""
 
-from .models import MacroParam, MacroDef
+from .models import (
+    ComplexDevice,
+    MacroDef,
+    MacroInstance,
+    MacroParam,
+)
+from .pinxml import macro_to_xml
 
-__all__ = ["MacroParam", "MacroDef"]
+__all__ = [
+    "MacroParam",
+    "MacroDef",
+    "MacroInstance",
+    "ComplexDevice",
+    "macro_to_xml",
+]
 

--- a/src/complex_editor/domain/models.py
+++ b/src/complex_editor/domain/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Dict, List
 
 
 @dataclass
@@ -17,4 +18,22 @@ class MacroDef:
     id_function: int
     name: str
     params: list[MacroParam]
+
+
+@dataclass
+class MacroInstance:
+    """One concrete use of a VIVA macro inside a complex."""
+
+    name: str
+    params: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class ComplexDevice:
+    """Full complex definition (pins live in tabCompDesc columns, not XML)."""
+
+    id_function: int
+    pins: List[str]
+    macro: MacroInstance
+
 

--- a/src/complex_editor/domain/pinxml.py
+++ b/src/complex_editor/domain/pinxml.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from xml.etree import ElementTree as ET
+
+from .models import MacroInstance
+
+__all__ = ["macro_to_xml"]
+
+
+def macro_to_xml(macro: MacroInstance) -> str:
+    """Return UTF-16-LE XML string for the given macro."""
+    root = ET.Element("R")
+    macros_el = ET.SubElement(root, "Macros")
+    macro_el = ET.SubElement(macros_el, "Macro", Name=macro.name)
+    for name, value in macro.params.items():
+        ET.SubElement(macro_el, "Param", Value=value, Name=name)
+    ET.indent(root, space="  ")
+    xml_body = ET.tostring(root, encoding="unicode")
+    return "<?xml version=\"1.0\" encoding=\"utf-16\"?>\n" + xml_body

--- a/tests/test_pinxml.py
+++ b/tests/test_pinxml.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+# Provide a dummy pyodbc module so import succeeds in CLI
+sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from complex_editor import cli  # noqa: E402
+from complex_editor.domain import MacroInstance, macro_to_xml  # noqa: E402
+
+EXPECTED_XML = (
+    "<?xml version=\"1.0\" encoding=\"utf-16\"?>\n"
+    "<R>\n"
+    "  <Macros>\n"
+    "    <Macro Name=\"GATE\">\n"
+    "      <Param Value=\"010101\" Name=\"PathPin_A\" />\n"
+    "      <Param Value=\"HLHLHL\" Name=\"PathPin_B\" />\n"
+    "    </Macro>\n"
+    "  </Macros>\n"
+    "</R>"
+)
+
+
+def test_macro_to_xml():
+    macro = MacroInstance("GATE", {"PathPin_A": "010101", "PathPin_B": "HLHLHL"})
+    out = macro_to_xml(macro)
+    assert out.replace("\r\n", "\n") == EXPECTED_XML
+    bytes_out = out.encode("utf-16le")
+    assert b"\xff\xfe" not in bytes_out
+
+
+def test_cli_make_pinxml(capsys):
+    exit_code = cli.main(
+        [
+            "make-pinxml",
+            "--macro",
+            "GATE",
+            "--param",
+            "PathPin_A=010101",
+            "--param",
+            "PathPin_B=HLHLHL",
+        ]
+    )
+    assert exit_code == 0
+    hex_out = capsys.readouterr().out.strip()
+    bytes_out = bytes.fromhex(hex_out)
+    xml = bytes_out.decode("utf-16le")
+    assert xml.replace("\r\n", "\n") == EXPECTED_XML


### PR DESCRIPTION
## Summary
- add `MacroInstance` and `ComplexDevice` dataclasses
- implement `macro_to_xml` for PinS XML output
- expose new functions and classes in domain package
- add `make-pinxml` CLI command to create macro XML
- test XML serialization and CLI round-trip

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862881775d4832cb480468e9e8cb612