### PR TITLE
Add GUI skeleton with PyQt and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,4 @@ dependencies = [
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
-dev = ["pytest", "ruff"]
+dev = ["pytest", "pytest-qt", "ruff"]

--- a/src/complex_editor/ui/__init__.py
+++ b/src/complex_editor/ui/__init__.py
@@ -1,1 +1,3 @@
-# ui components
+from .main_window import MainWindow, run_gui
+
+__all__ = ["MainWindow", "run_gui"]

--- a/src/complex_editor/ui/complex_editor.py
+++ b/src/complex_editor/ui/complex_editor.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from ..domain import ComplexDevice, MacroInstance, macro_to_xml
+from ..services import insert_complex
+from ..db import make_backup
+
+
+class ComplexEditor(QtWidgets.QWidget):
+    """Form for editing/creating a complex device."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QtWidgets.QVBoxLayout(self)
+        form = QtWidgets.QFormLayout()
+        self.pin_edits = [QtWidgets.QLineEdit() for _ in range(4)]
+        validator = QtGui.QRegularExpressionValidator(QtCore.QRegularExpression("[A-Za-z0-9]+"))
+        for i, edit in enumerate(self.pin_edits):
+            edit.setValidator(validator)
+            form.addRow(f"Pin {chr(65 + i)}", edit)
+        self.macro_combo = QtWidgets.QComboBox()
+        form.addRow("Macro", self.macro_combo)
+        layout.addLayout(form)
+        self.param_form = QtWidgets.QFormLayout()
+        layout.addLayout(self.param_form)
+        self.xml_preview = QtWidgets.QPlainTextEdit()
+        self.xml_preview.setReadOnly(True)
+        layout.addWidget(self.xml_preview)
+        self.save_btn = QtWidgets.QPushButton("Save")
+        layout.addWidget(self.save_btn)

--- a/src/complex_editor/ui/complex_list.py
+++ b/src/complex_editor/ui/complex_list.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from PyQt6 import QtCore, QtWidgets
+
+from ..db import fetch_comp_desc_rows
+
+
+class ComplexListModel(QtCore.QAbstractTableModel):
+    HEADERS = ["ID", "Macro", "PinA", "PinB", "PinC", "PinD", "PinS"]
+
+    def __init__(self, rows=None, macro_map=None):
+        super().__init__()
+        self.rows = list(rows or [])
+        self.macro_map = macro_map or {}
+
+    def load(self, rows, macro_map):
+        self.beginResetModel()
+        self.rows = list(rows)
+        self.macro_map = macro_map
+        self.endResetModel()
+
+    def rowCount(self, parent=None):
+        return len(self.rows)
+
+    def columnCount(self, parent=None):
+        return len(self.HEADERS)
+
+    def data(self, index, role):
+        if not index.isValid():
+            return None
+        if role == QtCore.Qt.ItemDataRole.DisplayRole:
+            row = self.rows[index.row()]
+            id_comp = getattr(row, "IDCompDesc", row[0])
+            id_func = getattr(row, "IDFunction", row[1])
+            macro = self.macro_map.get(int(id_func))
+            macro_name = macro.name if macro else str(id_func)
+            pin_a = getattr(row, "PinA", row[2])
+            pin_b = getattr(row, "PinB", row[3])
+            pin_c = getattr(row, "PinC", row[4])
+            pin_d = getattr(row, "PinD", row[5])
+            pin_s = "yes" if getattr(row, "PinS", row[6]) else ""
+            values = [id_comp, macro_name, pin_a, pin_b, pin_c, pin_d, pin_s]
+            return str(values[index.column()])
+        return None
+
+    def headerData(self, section, orientation, role):
+        if role == QtCore.Qt.ItemDataRole.DisplayRole and orientation == QtCore.Qt.Orientation.Horizontal:
+            return self.HEADERS[section]
+        return None
+
+
+class ComplexListPanel(QtWidgets.QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QtWidgets.QVBoxLayout(self)
+        self.view = QtWidgets.QTableView()
+        self.model = ComplexListModel([])
+        self.view.setModel(self.model)
+        self.view.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows)
+        self.view.setEditTriggers(QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers)
+        layout.addWidget(self.view)
+
+    def load_rows(self, cursor, macro_map):
+        rows = fetch_comp_desc_rows(cursor, 1000)
+        self.model.load(rows, macro_map)

--- a/src/complex_editor/ui/datasheet_viewer.py
+++ b/src/complex_editor/ui/datasheet_viewer.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+import fitz  # PyMuPDF
+
+
+class DatasheetViewer(QtWidgets.QWidget):
+    """Very small PDF/PNG viewer using PyMuPDF."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        layout = QtWidgets.QVBoxLayout(self)
+        self.label = QtWidgets.QLabel("No datasheet loaded")
+        self.label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.label)
+
+    def load_file(self, path: str) -> None:
+        doc = fitz.open(path)
+        if not doc.page_count:
+            return
+        page = doc.load_page(0)
+        pix = page.get_pixmap()
+        fmt = "PNG"
+        data = pix.tobytes(fmt)
+        image = QtGui.QImage.fromData(data, fmt)
+        self.label.setPixmap(QtGui.QPixmap.fromImage(image))

--- a/src/complex_editor/ui/icons/README.txt
+++ b/src/complex_editor/ui/icons/README.txt
@@ -1,0 +1,1 @@
+Placeholder icons use Qt built-ins

--- a/src/complex_editor/ui/main_window.py
+++ b/src/complex_editor/ui/main_window.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+from PyQt6 import QtWidgets
+
+from ..db import connect, discover_macro_map
+from .complex_list import ComplexListPanel
+from .complex_editor import ComplexEditor
+from .datasheet_viewer import DatasheetViewer
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    """Main application window."""
+
+    def __init__(self, conn: Optional[object] = None) -> None:
+        super().__init__()
+        self.conn = conn
+        self.cursor = conn.cursor() if conn else None
+        self.macro_map = {}
+        self.setWindowTitle("Complex Editor")
+        self._build_ui()
+        if self.cursor:
+            self.load_data()
+
+    def _build_ui(self) -> None:
+        central = QtWidgets.QWidget()
+        main_layout = QtWidgets.QHBoxLayout(central)
+        # Navigation bar
+        nav_widget = QtWidgets.QWidget()
+        nav_widget.setStyleSheet("background:#003D66;color:white")
+        nav_layout = QtWidgets.QVBoxLayout(nav_widget)
+        btn_program = QtWidgets.QPushButton("Program Configuration")
+        btn_program.clicked.connect(lambda: self.stack.setCurrentWidget(self.list_panel))
+        nav_layout.addWidget(btn_program)
+        nav_layout.addStretch()
+        main_layout.addWidget(nav_widget)
+        # Stacked area
+        self.stack = QtWidgets.QStackedWidget()
+        main_layout.addWidget(self.stack, 1)
+        self.list_panel = ComplexListPanel()
+        self.stack.addWidget(self.list_panel)
+        self.editor_panel = ComplexEditor()
+        self.stack.addWidget(self.editor_panel)
+        self.setCentralWidget(central)
+        # Menu
+        file_menu = self.menuBar().addMenu("File")
+        open_act = file_menu.addAction("Open…")
+        open_act.triggered.connect(self.open_mdb)
+
+    def open_mdb(self) -> None:
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Open MDB", filter="MDB Files (*.mdb *.accdb)")
+        if not path:
+            return
+        self.conn = connect(path)
+        self.cursor = self.conn.cursor()
+        self.load_data()
+
+    def load_data(self) -> None:
+        if not self.cursor:
+            return
+        self.macro_map = discover_macro_map(self.cursor)
+        self.list_panel.load_rows(self.cursor, self.macro_map)
+
+
+def run_gui(mdb_path: Optional[str] = None) -> None:
+    app = QtWidgets.QApplication(sys.argv)
+    conn = connect(mdb_path) if mdb_path else None
+    window = MainWindow(conn)
+    window.resize(800, 600)
+    window.show()
+    sys.exit(app.exec())

--- a/tests/test_ui_load.py
+++ b/tests/test_ui_load.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import types
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from complex_editor.ui.main_window import MainWindow  # noqa: E402
+
+
+class FakeCursor:
+    def tables(self, table=None, tableType=None):
+        yield types.SimpleNamespace(table_name="tabCompDesc")
+        yield types.SimpleNamespace(table_name="tabFunction")
+        yield types.SimpleNamespace(table_name="tabFuncMacro")
+
+    def columns(self, table):
+        if table == "tabCompDesc":
+            cols = [
+                "IDCompDesc",
+                "IDFunction",
+                "PinA",
+                "PinB",
+                "PinC",
+                "PinD",
+                "PinS",
+            ]
+        elif table == "tabFunction":
+            cols = ["IDFunction", "MacroName"]
+        else:
+            cols = [
+                "IDFunction",
+                "ParamName",
+                "ParamType",
+                "DefValue",
+                "MinValue",
+                "MaxValue",
+            ]
+        for c in cols:
+            yield types.SimpleNamespace(column_name=c)
+
+    def execute(self, query):
+        self.last_query = query
+        return self
+
+    def fetchall(self):
+        if "tabFunction" in self.last_query:
+            return [(1, "MACRO1")]
+        if "tabCompDesc" in self.last_query:
+            return [
+                (1, 1, "A1", "B1", None, None, None),
+                (2, 1, "A2", "B2", None, None, None),
+            ]
+        return []
+
+
+class FakeConnection:
+    def cursor(self):
+        return FakeCursor()
+
+
+def test_main_window_load(qtbot):
+    window = MainWindow(FakeConnection())
+    qtbot.addWidget(window)
+    model = window.list_panel.model
+    assert model.rowCount() == 2

--- a/ui_skeleton.py
+++ b/ui_skeleton.py
@@ -1,0 +1,4 @@
+from complex_editor.ui.main_window import run_gui
+
+if __name__ == "__main__":
+    run_gui()


### PR DESCRIPTION
## Summary
- restructure UI into package `complex_editor.ui`
- implement `MainWindow` with basic navigation and load capability
- add supporting widgets for list panel, editor form and datasheet viewer
- create entry script `ui_skeleton.py`
- add pytest-qt dev dependency
- include headless GUI test `test_ui_load`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686290393e50832c89549d4df5eb54c8