### PR TITLE
Implement new complex editor behavior

### DIFF
--- a/src/complex_editor/ui/complex_list.py
+++ b/src/complex_editor/ui/complex_list.py
@@ -58,6 +58,9 @@ class ComplexListPanel(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         layout = QtWidgets.QVBoxLayout(self)
+        btn_new = QtWidgets.QPushButton("New Complex")
+        btn_new.clicked.connect(lambda: self.complexSelected.emit(None))
+        layout.addWidget(btn_new)
         self.view = QtWidgets.QTableView()
         self.model = ComplexListModel([])
         self.view.setModel(self.model)

--- a/tests/test_ui_load.py
+++ b/tests/test_ui_load.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 import types
 import os
 import sys
+from pathlib import Path
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+pyodbc = sys.modules["pyodbc"]
+pyodbc.SQL_DATABASE_NAME = 0
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
+from PyQt6 import QtWidgets
 from complex_editor.ui.main_window import MainWindow  # noqa: E402
 
 
@@ -68,6 +72,9 @@ class FakeConnection:
     def cursor(self):
         return FakeCursor()
 
+    def getinfo(self, code):
+        return "dummy.mdb"
+
 
 def test_main_window_load(qtbot):
     window = MainWindow(FakeConnection())
@@ -80,10 +87,10 @@ def test_editor_save(qtbot, monkeypatch):
     conn = FakeConnection()
     window = MainWindow(conn)
     qtbot.addWidget(window)
-    index = window.list_panel.model.index(0, 0)
-    window.list_panel.view.clicked.emit(index)
-    assert window.editor_panel.pin_edits[0].text() == "A1"
-    assert window.editor_panel.macro_combo.currentText() == "MACRO1"
+    window.list_panel.complexSelected.emit(None)
+    window.editor_panel.pin_edits[0].setText("X1")
+    window.editor_panel.pin_edits[1].setText("X2")
+    window.editor_panel.macro_combo.setCurrentIndex(0)
     widget = window.editor_panel.param_widgets["P1"]
     widget.setValue(5)
 
@@ -94,7 +101,20 @@ def test_editor_save(qtbot, monkeypatch):
     monkeypatch.setattr(
         "complex_editor.ui.complex_editor.insert_complex", fake_insert
     )
+    bak_called = {}
+    monkeypatch.setattr(
+        "complex_editor.ui.complex_editor.make_backup",
+        lambda p: (bak_called.setdefault("path", p), Path("backup.bak"))[1],
+    )
+    info_text = {}
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "information",
+        lambda *a, **k: info_text.setdefault("msg", a[2]),
+    )
     monkeypatch.setattr(window.list_panel, "load_rows", lambda c, m: None)
     window.editor_panel.conn = conn
     window.editor_panel.save_complex()
     assert window.list_panel.model.rowCount() == 3
+    assert Path("backup.bak") == Path(info_text["msg"].split()[-1])
+    assert bak_called["path"] == "dummy.mdb"


### PR DESCRIPTION
## Summary
- handle macro changes in ComplexEditor and connect to combo box
- add database backup step in save_complex
- support creating a new complex from ComplexListPanel
- allow clearing editor when None passed to load_complex
- support simple ENUM choices parsing
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862954840dc832c945f90b798978578