### PR TITLE
Add editor navigation method

### DIFF
--- a/src/complex_editor/ui/main_window.py
+++ b/src/complex_editor/ui/main_window.py
@@ -45,7 +45,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.editor_panel.conn = self.conn
         self.editor_panel.dirtyChanged.connect(self._on_dirty)
         self.stack.addWidget(self.editor_panel)
-        self.list_panel.complexSelected.connect(self.editor_panel.load_complex)
+        self.list_panel.complexSelected.connect(self._open_editor)
         self.setCentralWidget(central)
         # Menu
         file_menu = self.menuBar().addMenu("File")
@@ -54,6 +54,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.save_act = file_menu.addAction("Save")
         self.save_act.triggered.connect(self.editor_panel.save_complex)
         self.save_act.setEnabled(False)
+
+    def _open_editor(self, row) -> None:
+        """Open the editor panel for the selected complex."""
+        self.editor_panel.load_complex(row)
+        self.stack.setCurrentWidget(self.editor_panel)
 
     def open_mdb(self) -> None:
         path, _ = QtWidgets.QFileDialog.getOpenFileName(


### PR DESCRIPTION
## Summary
- open complex editor when a complex is selected

## Testing
- `pytest tests/test_ui_load.py::test_main_window_load -q`
- `pytest tests/test_ui_load.py::test_editor_save -q`
- `pytest -q` *(fails: MacroParam.__init__() got an unexpected keyword argument 'unit')*

------
https://chatgpt.com/codex/tasks/task_e_68638b58ae74832cb9c1a721b4626fda