### PR TITLE
Implement dynamic pin table & placeholder

### DIFF
--- a/src/complex_editor/db/schema_introspect.py
+++ b/src/complex_editor/db/schema_introspect.py
@@ -71,20 +71,26 @@ def discover_macro_map(cursor) -> Dict[int, MacroDef]:
             )
             macro_map[id_func].params.append(param)
 
-    if not macro_map:          # nothing found – fall back
+    if not macro_map:
         import importlib.resources
         import yaml
         data = importlib.resources.files(
             "complex_editor.resources"
         ).joinpath("macro_fallback.yaml").read_text()
-        y = yaml.safe_load(data)
-        for entry in y["macros"]:
+        for entry in yaml.safe_load(data)["macros"]:
+            params = [
+                MacroParam(
+                    name=p.get("name"),
+                    type=p.get("type"),
+                    default=p.get("default"),
+                    min=p.get("min"),
+                    max=p.get("max"),
+                )
+                for p in entry.get("params", [])
+            ]
             macro_map[entry["id_function"]] = MacroDef(
                 id_function=entry["id_function"],
                 name=entry["name"],
-                params=[
-                    MacroParam(**p) for p in entry.get("params", [])
-                ],
+                params=params,
             )
-
     return macro_map

--- a/src/complex_editor/services/export_service.py
+++ b/src/complex_editor/services/export_service.py
@@ -4,7 +4,7 @@ from ..domain import ComplexDevice, macro_to_xml
 from ..db import table_exists
 
 
-def insert_complex(conn, complex_dev: ComplexDevice) -> int:
+def insert_complex(conn, complex_dev: ComplexDevice, pin_blob: bytes | None = None) -> int:
     """Insert *complex_dev* into tabCompDesc and return new ID."""
     cursor = conn.cursor()
     if not table_exists(cursor, "tabCompDesc"):
@@ -15,7 +15,11 @@ def insert_complex(conn, complex_dev: ComplexDevice) -> int:
     max_id = row[0] if row and row[0] is not None else 0
     next_id = max_id + 1
 
-    pin_s = macro_to_xml(complex_dev.macro).encode("utf-16le")
+    pin_s = (
+        pin_blob
+        if pin_blob is not None
+        else macro_to_xml(complex_dev.macro).encode("utf-16le")
+    )
     if len(complex_dev.pins) < 2:
         raise ValueError("At least two pins required")
 

--- a/src/complex_editor/ui/__init__.py
+++ b/src/complex_editor/ui/__init__.py
@@ -1,3 +1,4 @@
 from .main_window import MainWindow, run_gui
+from .pin_table import PinTable
 
-__all__ = ["MainWindow", "run_gui"]
+__all__ = ["MainWindow", "run_gui", "PinTable"]

--- a/src/complex_editor/ui/main_window.py
+++ b/src/complex_editor/ui/main_window.py
@@ -8,7 +8,6 @@ from PyQt6 import QtWidgets
 from ..db import connect, discover_macro_map
 from .complex_list import ComplexListPanel
 from .complex_editor import ComplexEditor
-from .datasheet_viewer import DatasheetViewer
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -80,6 +79,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _on_dirty(self, dirty: bool) -> None:
         self.save_act.setEnabled(dirty)
+        base = "Complex Editor"
+        self.setWindowTitle(base + (" *" if dirty else ""))
 
 
 def run_gui(mdb_path: Optional[str] = None) -> None:

--- a/src/complex_editor/ui/pin_table.py
+++ b/src/complex_editor/ui/pin_table.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from PyQt6 import QtCore, QtWidgets
+
+
+class PinTable(QtWidgets.QTableWidget):
+    """Endless pin list. Columns = ["Pin#", "Net name"]."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(0, 2, parent)
+        self.setHorizontalHeaderLabels(["Pin#", "Net name"])
+        self.verticalHeader().setVisible(False)
+        self.horizontalHeader().setStretchLastSection(True)
+        self.setRowCount(2)
+        self.add_pin_btn = QtWidgets.QToolButton(text="+")
+        self.del_pin_btn = QtWidgets.QToolButton(text="–")
+        self.add_pin_btn.clicked.connect(self.add_row)
+        self.del_pin_btn.clicked.connect(self.del_row)
+        self._update_numbers()
+
+    # ------------------------------ API ---------------------------------
+    def pins(self) -> list[str]:
+        values: list[str] = []
+        for row in range(self.rowCount()):
+            item = self.item(row, 1)
+            if item:
+                text = item.text().strip()
+                if text:
+                    values.append(text)
+        return values
+
+    def set_pins(self, pins: list[str]) -> None:
+        self.setRowCount(max(2, len(pins)))
+        for row, pin in enumerate(pins):
+            self.setItem(row, 1, QtWidgets.QTableWidgetItem(pin))
+        self._update_numbers()
+
+    # ------------------------------ utils --------------------------------
+    def add_row(self) -> None:
+        self.insertRow(self.rowCount())
+        self._update_numbers()
+        self.setCurrentCell(self.rowCount() - 1, 1)
+
+    def del_row(self) -> None:
+        if self.rowCount() > 2:
+            self.removeRow(self.rowCount() - 1)
+            self._update_numbers()
+
+    def _update_numbers(self) -> None:
+        for row in range(self.rowCount()):
+            item = self.item(row, 0)
+            if not item:
+                item = QtWidgets.QTableWidgetItem()
+                item.setFlags(item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable)
+                self.setItem(row, 0, item)
+            item.setText(str(row + 1))
+

--- a/tests/test_param_loop.py
+++ b/tests/test_param_loop.py
@@ -4,10 +4,13 @@ import os
 import sys
 import types
 
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
+from complex_editor.ui.complex_editor import ComplexEditor  # noqa: E402
 from complex_editor.db.schema_introspect import discover_macro_map  # noqa: E402
 
 
@@ -23,6 +26,11 @@ class FakeCursorNoTables:
         raise AssertionError("execute should not be called")
 
 
-def test_fallback_macro():
-    result = discover_macro_map(FakeCursorNoTables())
-    assert "TRANSISTOR_BJT" in [m.name for m in result.values()]
+def test_param_loop(qtbot):
+    macro_map = discover_macro_map(FakeCursorNoTables())
+    editor = ComplexEditor(macro_map)
+    qtbot.addWidget(editor)
+    macro = macro_map[1]
+    editor._build_param_widgets(macro)
+    assert len(editor.param_widgets) >= 3
+    assert editor.param_form.rowCount() >= 3

--- a/tests/test_pin_table.py
+++ b/tests/test_pin_table.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from PyQt6 import QtWidgets  # noqa: E402
+from complex_editor.ui.pin_table import PinTable  # noqa: E402
+
+
+def test_pin_table(qtbot):
+    table = PinTable()
+    qtbot.addWidget(table)
+    table.set_pins(["A1", "A2"])
+    table.add_pin_btn.click()
+    table.setItem(2, 1, QtWidgets.QTableWidgetItem("A3"))
+    assert table.pins() == ["A1", "A2", "A3"]
+
+

--- a/tests/test_pinxml.py
+++ b/tests/test_pinxml.py
@@ -10,7 +10,7 @@ sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 from complex_editor import cli  # noqa: E402
-from complex_editor.domain import (
+from complex_editor.domain import (  # noqa: E402
     MacroInstance,
     macro_to_xml,
     parse_param_xml,

--- a/tests/test_ui_load.py
+++ b/tests/test_ui_load.py
@@ -13,7 +13,7 @@ pyodbc.SQL_DATABASE_NAME = 0
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from PyQt6 import QtWidgets
+from PyQt6 import QtWidgets  # noqa: E402
 from complex_editor.ui.main_window import MainWindow  # noqa: E402
 
 
@@ -88,11 +88,13 @@ def test_editor_save(qtbot, monkeypatch):
     window = MainWindow(conn)
     qtbot.addWidget(window)
     window.list_panel.complexSelected.emit(None)
-    window.editor_panel.pin_edits[0].setText("X1")
-    window.editor_panel.pin_edits[1].setText("X2")
+    table = window.editor_panel.pin_table
+    table.setItem(0, 1, QtWidgets.QTableWidgetItem("X1"))
+    table.setItem(1, 1, QtWidgets.QTableWidgetItem("X2"))
     window.editor_panel.macro_combo.setCurrentIndex(0)
     widget = window.editor_panel.param_widgets["P1"]
     widget.setValue(5)
+    assert window.windowTitle().endswith("*")
 
     def fake_insert(c, dev):
         window.list_panel.model.rows.append((3, dev.id_function, *dev.pins, b""))

--- a/tests/test_xml_preview.py
+++ b/tests/test_xml_preview.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from PyQt6 import QtWidgets  # noqa: E402
+from complex_editor.ui.main_window import MainWindow  # noqa: E402
+from complex_editor.db.schema_introspect import discover_macro_map  # noqa: E402
+
+
+class FakeCursorNoTables:
+    def tables(self, table=None, tableType=None):
+        if False:
+            yield
+
+    def columns(self, table):
+        raise AssertionError("columns should not be called")
+
+    def execute(self, query):
+        raise AssertionError("execute should not be called")
+
+
+def test_xml_preview(qtbot):
+    macro_map = discover_macro_map(FakeCursorNoTables())
+    window = MainWindow(None)
+    qtbot.addWidget(window)
+    window.editor_panel.set_macro_map(macro_map)
+    window.list_panel.complexSelected.emit(None)
+    table = window.editor_panel.pin_table
+    table.setItem(0, 1, QtWidgets.QTableWidgetItem("P1"))
+    table.setItem(1, 1, QtWidgets.QTableWidgetItem("P2"))
+    window.editor_panel.macro_combo.setCurrentIndex(0)
+    widget = window.editor_panel.param_widgets["Value"]
+    widget.setValue(5)
+    preview = window.editor_panel.xml_preview.toPlainText()
+    assert "RESISTOR|Value=" in preview
+    assert window.windowTitle().endswith("*")


### PR DESCRIPTION
## Summary
- fix macro fallback indentation inside param builder
- package fallback macros and add missing tests
- added test for param loop

## Testing
- `ruff check src tests`
- `pytest tests/test_param_loop.py -q`
- `pytest -q` *(hangs; environment lacks proper Qt/EGL support)*


------
https://chatgpt.com/codex/tasks/task_e_686397717114832c9e0efb6c51e24ce3