### PR TITLE
Polish wizard navigation and editor

### DIFF
--- a/src/complex_editor/ui/main_window.py
+++ b/src/complex_editor/ui/main_window.py
@@ -65,6 +65,7 @@ class MainWindow(QtWidgets.QMainWindow):
         wizard = NewComplexWizard(self.macro_map, self)
         if wizard.exec() == QtWidgets.QDialog.DialogCode.Accepted:
             self.editor_panel.load_complex(None)
+            self.editor_panel.set_sub_components(wizard.sub_components)
             if wizard.sub_components:
                 sc = wizard.sub_components[0]
                 pins = [str(p) for p in sc.pins]

--- a/src/complex_editor/ui/pin_table.py
+++ b/src/complex_editor/ui/pin_table.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PyQt6 import QtWidgets
+from PyQt6 import QtGui, QtWidgets
 
 
 class PinTable(QtWidgets.QTableWidget):
@@ -25,3 +25,15 @@ class PinTable(QtWidgets.QTableWidget):
             item = self.item(i, 0)
             result.append(item.text() if item else "")
         return result
+
+    def highlight_pins(self, numbers: list[int]) -> None:
+        """Highlight given pin numbers with a yellow background."""
+        color = QtGui.QColor("yellow")
+        for row in range(self.rowCount()):
+            item = self.item(row, 0)
+            if not item:
+                continue
+            if (row + 1) in numbers:
+                item.setBackground(color)
+            else:
+                item.setBackground(QtGui.QColor("white"))

--- a/tests/test_param_loop.py
+++ b/tests/test_param_loop.py
@@ -37,3 +37,5 @@ def test_param_loop(qtbot):
     assert editor.param_form.rowCount() == first_count
     assert len(editor.param_widgets) >= 3
     assert editor.param_form.rowCount() > 1
+    for name, widget in editor.param_widgets.items():
+        assert name in widget.toolTip()

--- a/tests/test_wizard_next_disable.py
+++ b/tests/test_wizard_next_disable.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from PyQt6 import QtCore  # noqa: E402
+from complex_editor.ui.new_complex_wizard import NewComplexWizard  # noqa: E402
+from complex_editor.db.schema_introspect import discover_macro_map  # noqa: E402
+
+
+class FakeCursorNoTables:
+    def tables(self, table=None, tableType=None):
+        if False:
+            yield
+
+    def columns(self, table):
+        raise AssertionError
+
+    def execute(self, query):
+        raise AssertionError
+
+
+def test_next_disabled_until_pin_checked(qtbot):
+    macro_map = discover_macro_map(FakeCursorNoTables())
+    wiz = NewComplexWizard(macro_map)
+    qtbot.addWidget(wiz)
+    wiz.basics_page.pin_spin.setValue(4)
+    wiz._next()  # to list
+    wiz.list_page.add_btn.click()
+    assert not wiz.next_btn.isEnabled()
+    wiz.macro_page.pin_list.item(0).setCheckState(QtCore.Qt.CheckState.Checked)
+    wiz._update_nav()
+    assert wiz.next_btn.isEnabled()


### PR DESCRIPTION
## Summary
- add sub-component list preview with pin highlighting
- infer parameter ranges on tooltips
- validate wizard navigation steps
- test widgets for tooltips
- test wizard next button disabling

## Testing
- `ruff check . --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a743cc820832c8ff28b70a2967874