### PR TITLE
Fix wizard pin ordering and macro combo

### DIFF
--- a/src/complex_editor/ui/complex_editor.py
+++ b/src/complex_editor/ui/complex_editor.py
@@ -42,6 +42,7 @@ class ComplexEditor(QtWidgets.QWidget):
         self.pin_table = PinTable()
         form.addRow("Pins", self.pin_table)
         self.macro_combo = QtWidgets.QComboBox()
+        self._last_idx = -1
         form.addRow("Macro", self.macro_combo)
         layout.addLayout(form)
         self.param_form = QtWidgets.QFormLayout()
@@ -84,6 +85,9 @@ class ComplexEditor(QtWidgets.QWidget):
             self.pin_table.highlight_pins([])
 
     def _on_macro_change(self) -> None:
+        if self.macro_combo.currentIndex() == self._last_idx:
+            return
+        self._last_idx = self.macro_combo.currentIndex()
         data = self.macro_combo.currentData()
         macro = self.macro_map.get(int(data)) if data is not None else None
         self._build_param_widgets(macro)

--- a/src/complex_editor/ui/pin_table.py
+++ b/src/complex_editor/ui/pin_table.py
@@ -33,7 +33,11 @@ class PinTable(QtWidgets.QTableWidget):
             item = self.item(row, 0)
             if not item:
                 continue
+            font = item.font()
             if (row + 1) in numbers:
                 item.setBackground(color)
+                font.setBold(True)
             else:
                 item.setBackground(QtGui.QColor("white"))
+                font.setBold(False)
+            item.setFont(font)

--- a/tests/test_wizard_creates_editor_state.py
+++ b/tests/test_wizard_creates_editor_state.py
@@ -10,7 +10,6 @@ sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from PyQt6 import QtCore  # noqa: E402
 from complex_editor.ui.new_complex_wizard import NewComplexWizard  # noqa: E402
 from complex_editor.ui.main_window import MainWindow  # noqa: E402
 from complex_editor.db.schema_introspect import discover_macro_map  # noqa: E402
@@ -42,8 +41,8 @@ def test_wizard_creates_editor_state(qtbot):
     wizard.list_page.add_btn.click()
     idx = wizard.macro_page.macro_combo.findText("RESISTOR")
     wizard.macro_page.macro_combo.setCurrentIndex(idx)
-    wizard.macro_page.pin_list.item(0).setCheckState(QtCore.Qt.CheckState.Checked)
-    wizard.macro_page.pin_list.item(1).setCheckState(QtCore.Qt.CheckState.Checked)
+    wizard.macro_page.pin_table.cellWidget(0, 1).setValue(1)
+    wizard.macro_page.pin_table.cellWidget(1, 1).setValue(2)
     wizard._next()
     wizard._next()  # param -> list
     wizard._next()  # list -> review

--- a/tests/test_wizard_flow.py
+++ b/tests/test_wizard_flow.py
@@ -10,7 +10,7 @@ sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from PyQt6 import QtCore, QtWidgets  # noqa: E402
+from PyQt6 import QtWidgets  # noqa: E402
 from complex_editor.ui.new_complex_wizard import NewComplexWizard  # noqa: E402
 from complex_editor.db.schema_introspect import discover_macro_map  # noqa: E402
 
@@ -36,8 +36,8 @@ def test_wizard_flow(qtbot):
     wizard.list_page.add_btn.click()
     idx = wizard.macro_page.macro_combo.findText("RESISTOR")
     wizard.macro_page.macro_combo.setCurrentIndex(idx)
-    wizard.macro_page.pin_list.item(0).setCheckState(QtCore.Qt.CheckState.Checked)
-    wizard.macro_page.pin_list.item(1).setCheckState(QtCore.Qt.CheckState.Checked)
+    wizard.macro_page.pin_table.cellWidget(0, 1).setValue(1)
+    wizard.macro_page.pin_table.cellWidget(1, 1).setValue(2)
     wizard._next()  # to param page
     val_widget = wizard.param_page.widgets.get("Value")
     if isinstance(val_widget, QtWidgets.QSpinBox):
@@ -45,8 +45,8 @@ def test_wizard_flow(qtbot):
     wizard._next()  # save params back to list
     wizard.list_page.list.setCurrentRow(0)
     wizard.list_page.dup_btn.click()
-    wizard.macro_page.pin_list.item(2).setCheckState(QtCore.Qt.CheckState.Checked)
-    wizard.macro_page.pin_list.item(3).setCheckState(QtCore.Qt.CheckState.Checked)
+    wizard.macro_page.pin_table.cellWidget(2, 1).setValue(1)
+    wizard.macro_page.pin_table.cellWidget(3, 1).setValue(2)
     wizard._next()
     wizard.param_page.copy_btn.click()
     dlg = wizard.param_page._copy_dialog

--- a/tests/test_wizard_next_disable.py
+++ b/tests/test_wizard_next_disable.py
@@ -10,7 +10,6 @@ sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from PyQt6 import QtCore  # noqa: E402
 from complex_editor.ui.new_complex_wizard import NewComplexWizard  # noqa: E402
 from complex_editor.db.schema_introspect import discover_macro_map  # noqa: E402
 
@@ -35,6 +34,12 @@ def test_next_disabled_until_pin_checked(qtbot):
     wiz._next()  # to list
     wiz.list_page.add_btn.click()
     assert not wiz.next_btn.isEnabled()
-    wiz.macro_page.pin_list.item(0).setCheckState(QtCore.Qt.CheckState.Checked)
+    wiz.macro_page.pin_table.cellWidget(0, 1).setValue(1)
+    wiz._update_nav()
+    assert wiz.next_btn.isEnabled()
+    wiz.macro_page.pin_table.cellWidget(1, 1).setValue(1)
+    wiz._update_nav()
+    assert not wiz.next_btn.isEnabled()
+    wiz.macro_page.pin_table.cellWidget(1, 1).setValue(2)
     wiz._update_nav()
     assert wiz.next_btn.isEnabled()


### PR DESCRIPTION
## Summary
- guard macro combo change signal to avoid resets
- use pin table with order values in wizard
- validate unique pin order before enabling navigation
- highlight selected pins in bold
- update wizard tests for new pin table

## Testing
- `ruff check src tests`
- `pytest -q` *(fails: ImportError from PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_686a84c73e74832c98c0846fdae0c23a