### PR TITLE
Allow Next on New Complex wizard when pads left blank

### DIFF
--- a/src/complex_editor/ui/new_complex_wizard.py
+++ b/src/complex_editor/ui/new_complex_wizard.py
@@ -133,7 +133,6 @@ class MacroPinsPage(QtWidgets.QWidget):
         """
         seen: dict[int, int] = {}
         duplicates: set[int] = set()
-        all_selected = True
 
         for row in range(self.pin_table.rowCount()):
             combo: QtWidgets.QComboBox = self.pin_table.cellWidget(row, 1)
@@ -141,7 +140,6 @@ class MacroPinsPage(QtWidgets.QWidget):
             combo.setStyleSheet("")
 
             if not text:
-                all_selected = False
                 continue
             val = int(text)
             if val in seen:
@@ -151,7 +149,7 @@ class MacroPinsPage(QtWidgets.QWidget):
         for row in duplicates:
             self.pin_table.cellWidget(row, 1).setStyleSheet("background:#FFCCCC;")
 
-        mapping_ok = all_selected and not duplicates
+        mapping_ok = not duplicates
         wiz = self.parentWidget().parent()        # the QDialog
         wiz._mapping_ok = mapping_ok
         wiz._update_nav()


### PR DESCRIPTION
## Summary
- permit incomplete pin assignments in MacroPinsPage
- only disable Next/Finish when duplicate pad numbers are chosen

## Testing
- `pytest -q` *(fails: ImportError from PyQt6 missing system libs)*

------
https://chatgpt.com/codex/tasks/task_e_686e2cf1b938832c98791226699fa9e5