### PR TITLE
Allow Next on New Complex wizard when pads left blank

### DIFF
--- a/src/complex_editor/ui/new_complex_wizard.py
+++ b/src/complex_editor/ui/new_complex_wizard.py
@@ -60,16 +60,24 @@ class MacroPinsPage(QtWidgets.QWidget):
         except Exception:
             names = []
 
-        if names:
-            self.macro_combo.addItems(names)
-            # default to first name that exists in macro_map
-            for i, name in enumerate(names):
-                if any(m.name == name for m in self.macro_map.values()):
-                    self.macro_combo.setCurrentIndex(i)
-                    break
-        else:
+        base_map = self.macro_map
+        existing_names = {m.name for m in base_map.values()}
+        next_id = -1
+        for name in names:
+            if name not in existing_names:
+                while next_id in base_map:
+                    next_id -= 1
+                base_map[next_id] = MacroDef(id_function=next_id, name=name, params=[])
+                next_id -= 1
+        self.macro_map = base_map
+
+        if not self.macro_map:
             self.macro_combo.addItem("⚠  No macros loaded")
             self.macro_combo.setEnabled(False)
+        else:
+            for id_func, macro in self.macro_map.items():
+                self.macro_combo.addItem(macro.name, id_func)
+            self.macro_combo.setCurrentIndex(0)
         vbox.addWidget(self.macro_combo)
 
         # ── ordered-pin table ───────────────────────────────────────────
@@ -87,8 +95,8 @@ class MacroPinsPage(QtWidgets.QWidget):
     # public helpers used by the wizard
     # ------------------------------------------------------------------
     def set_pin_count(self, total_pads: int, used_by_other_subs: set[int]) -> None:
-        name = self.macro_combo.currentText()
-        macro = next((m for m in self.macro_map.values() if m.name == name), None)
+        idfunc = self.macro_combo.currentData()
+        macro = self.macro_map.get(int(idfunc)) if idfunc is not None else None
         logical_names = [
             "Pin A",
             "Pin B",
@@ -133,7 +141,6 @@ class MacroPinsPage(QtWidgets.QWidget):
         """
         seen: dict[int, int] = {}
         duplicates: set[int] = set()
-        all_selected = True
 
         for row in range(self.pin_table.rowCount()):
             combo: QtWidgets.QComboBox = self.pin_table.cellWidget(row, 1)
@@ -141,7 +148,6 @@ class MacroPinsPage(QtWidgets.QWidget):
             combo.setStyleSheet("")
 
             if not text:
-                all_selected = False
                 continue
             val = int(text)
             if val in seen:
@@ -151,7 +157,7 @@ class MacroPinsPage(QtWidgets.QWidget):
         for row in duplicates:
             self.pin_table.cellWidget(row, 1).setStyleSheet("background:#FFCCCC;")
 
-        mapping_ok = all_selected and not duplicates
+        mapping_ok = not duplicates
         wiz = self.parentWidget().parent()        # the QDialog
         wiz._mapping_ok = mapping_ok
         wiz._update_nav()
@@ -354,8 +360,8 @@ class NewComplexWizard(QtWidgets.QDialog):
         self._update_nav()
 
     def _open_param_page(self) -> None:
-        name = self.macro_page.macro_combo.currentText()
-        macro = next((m for m in self.macro_map.values() if m.name == name), None)
+        index = self.macro_page.macro_combo.currentData()
+        macro = self.macro_map.get(int(index)) if index is not None else None
         if not macro and self.macro_map:
             macro = list(self.macro_map.values())[0]
         pins = self.macro_page.checked_pins()


### PR DESCRIPTION
## Summary
- permit incomplete pin assignments in MacroPinsPage
- populate macro list with functions_ref names as dummy MacroDefs
- look up selected macro by ID again

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_686e2cf1b938832c98791226699fa9e5