### PR TITLE
Add param bounds from YAML

### DIFF
--- a/src/complex_editor/db/schema_introspect.py
+++ b/src/complex_editor/db/schema_introspect.py
@@ -24,7 +24,6 @@ def discover_macro_map(cursor) -> Dict[int, MacroDef]:
     """Discover mapping from IDFunction to :class:`MacroDef`."""
     # If there’s no DB connection, just load the YAML fallback immediately.
     if cursor is None:
-        from pathlib import Path
         import yaml, importlib.resources
 
         pkg_files = importlib.resources.files("complex_editor.resources")

--- a/src/complex_editor/resources/macro_fallback.yaml
+++ b/src/complex_editor/resources/macro_fallback.yaml
@@ -1,0 +1,29 @@
+macros:
+  - id_function: 1
+    name: RESISTOR
+    params:
+      - name: Value
+        type: INT
+        default: "0"
+        min: "0"
+        max: "100"
+  - id_function: 2
+    name: CAPACITOR
+    params:
+      - name: Value
+        type: FLOAT
+        default: "0.0"
+        min: "0"
+        max: "1"
+  - id_function: 3
+    name: GATE
+    params:
+      - name: PathPin_A
+        type: ENUM
+        default: "0101"
+  - id_function: 4
+    name: TRANSISTOR_BJT
+    params: []
+  - id_function: 5
+    name: VOLTAGE_REGULATOR
+    params: []


### PR DESCRIPTION
## Summary
- load `function_param_allowed.yaml` at startup
- support numeric ranges and enums in wizard params
- provide a minimal `macro_fallback.yaml`
- fix `schema_introspect` fallback imports

## Testing
- `pytest -q` *(fails: ImportError: PyQt6 QtCore undefined symbol)*

------
https://chatgpt.com/codex/tasks/task_e_6874bc9c88fc832c8e480b9be064e058