### PR TITLE
Improve new complex wizard UX

### DIFF
--- a/src/complex_editor/ui/pin_table.py
+++ b/src/complex_editor/ui/pin_table.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, cast
 from PyQt6 import QtGui, QtWidgets
 
 
@@ -10,9 +10,8 @@ class PinTable(QtWidgets.QTableWidget):
     def __init__(self, parent=None) -> None:
         super().__init__(0, 1, parent)
         self.setHorizontalHeaderLabels(["Pin"])
-        self.horizontalHeader().setSectionResizeMode(
-            QtWidgets.QHeaderView.ResizeMode.Stretch
-        )
+        hdr = cast(QtWidgets.QHeaderView, self.horizontalHeader())
+        hdr.setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Stretch)
 
     def set_pins(self, pins: list[str]) -> None:
         self.setRowCount(len(pins))

--- a/tests/test_param_validate.py
+++ b/tests/test_param_validate.py
@@ -38,7 +38,6 @@ def test_validation_and_overrides(qtbot):
     wiz.macro_page.macro_combo.setCurrentIndex(idx)
     wiz.macro_page.pin_table.cellWidget(0, 1).setCurrentText("1")
     wiz.macro_page.pin_table.cellWidget(1, 1).setCurrentText("2")
-    wiz._next()
     spin = wiz.param_page.widgets.get("Value")
     assert isinstance(spin, QtWidgets.QSpinBox)
     spin.setValue(1)
@@ -52,7 +51,6 @@ def test_validation_and_overrides(qtbot):
     wiz.macro_page.macro_combo.setCurrentIndex(idx)
     wiz.macro_page.pin_table.cellWidget(0, 1).setCurrentText("3")
     wiz.macro_page.pin_table.cellWidget(1, 1).setCurrentText("4")
-    wiz._next()
     wiz._next()
     assert wiz.sub_components[1].macro.overrides == []
 

--- a/tests/test_wizard_creates_editor_state.py
+++ b/tests/test_wizard_creates_editor_state.py
@@ -45,7 +45,6 @@ def test_wizard_creates_editor_state(qtbot):
     wizard.macro_page.macro_combo.setCurrentIndex(idx)
     wizard.macro_page.pin_table.cellWidget(0, 1).setCurrentText("1")
     wizard.macro_page.pin_table.cellWidget(1, 1).setCurrentText("2")
-    wizard._next()
     wizard._next()  # param -> list
     wizard._next()  # list -> review
     wizard.review_page.save_btn.click()

--- a/tests/test_wizard_flow.py
+++ b/tests/test_wizard_flow.py
@@ -38,16 +38,16 @@ def test_wizard_flow(qtbot):
     wizard.macro_page.macro_combo.setCurrentIndex(idx)
     wizard.macro_page.pin_table.cellWidget(0, 1).setCurrentText("1")
     wizard.macro_page.pin_table.cellWidget(1, 1).setCurrentText("2")
-    wizard._next()  # to param page
     val_widget = wizard.param_page.widgets.get("Value")
     if isinstance(val_widget, QtWidgets.QSpinBox):
         val_widget.setValue(10)
     wizard._next()  # save params back to list
     wizard.list_page.list.setCurrentRow(0)
     wizard.list_page.dup_btn.click()
+    wizard._back()
     wizard.macro_page.pin_table.cellWidget(0, 1).setCurrentText("3")
+    wizard._back()
     wizard.macro_page.pin_table.cellWidget(1, 1).setCurrentText("4")
-    wizard._next()  # to param page
     val_widget2 = wizard.param_page.widgets.get("Value")
     if isinstance(val_widget2, QtWidgets.QSpinBox):
         assert val_widget2.value() == 10


### PR DESCRIPTION
## Summary
- auto-navigate from pin mapping to parameter page when mapping complete
- allow duplicating sub-components and jump straight to parameter page
- adjust list duplication logic and header setup casting
- update tests for new wizard flow
- add type hints and casts for mypy

## Testing
- `pytest -q`
- `mypy --config-file mypy.ini src`


------
https://chatgpt.com/codex/tasks/task_e_68763f440f74832ca13268e35ed05287