### PR TITLE
Fix CLI bootstrap and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@
 ```bash
 git clone https://github.com/your‑org/complex‑editor.git
 cd complex‑editor
-python -m venv .venv && source .venv/bin/activate      # Windows: .\.venv\Scripts\activate
+
+# optional: start fresh
+rm -rf .venv                 # PowerShell: Remove-Item -Recurse -Force .venv
+py -3.12 -m venv .venv
+source .venv/Scripts/activate
 pip install -r requirements.txt
 python -m complex_editor.cli --help
 python ui_skeleton.py          # works from project root without PYTHONPATH hacks

--- a/complex_editor/__init__.py
+++ b/complex_editor/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pkgutil
+
+# Include the real package located under src/ so "python -m complex_editor.cli"
+# works when the project is not installed.
+__path__ = pkgutil.extend_path(__path__, __name__)
+_src = Path(__file__).resolve().parent.parent / "src" / __name__
+if _src.exists():
+    __path__.append(str(_src))
+
+try:
+    from .bootstrap import add_repo_src_to_syspath  # type: ignore
+except Exception:
+    pass
+else:
+    add_repo_src_to_syspath()

--- a/src/complex_editor/bootstrap.py
+++ b/src/complex_editor/bootstrap.py
@@ -1,12 +1,22 @@
+"""Bootstrap helpers for working from a repo checkout."""
+
+from __future__ import annotations
+
 from pathlib import Path
+import importlib.util
+import logging
 import sys
 
 
 def add_repo_src_to_syspath() -> None:
-    """Prepend the repository's src directory to ``sys.path`` if needed."""
-    repo_root = Path(__file__).resolve().parents[2]
-    src_root = repo_root / "src"
+    """Prepend ``<repo-root>/src`` to ``sys.path`` if needed."""
+
+    if importlib.util.find_spec("complex_editor") is not None:
+        return
+
+    src_root = Path(__file__).resolve().parents[2] / "src"
     if src_root.exists() and str(src_root) not in sys.path:
         sys.path.insert(0, str(src_root))
+        logging.getLogger(__name__).info("Added %s to sys.path", src_root)
 
 __all__ = ["add_repo_src_to_syspath"]

--- a/ui_skeleton.py
+++ b/ui_skeleton.py
@@ -1,7 +1,16 @@
 # ruff: noqa: E402
+
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent
+SRC_ROOT = ROOT / "src"
+sys.path.insert(0, str(SRC_ROOT))
+
 from complex_editor.bootstrap import add_repo_src_to_syspath
 
 add_repo_src_to_syspath()
+import complex_editor.logging_cfg  # noqa: F401
 
 from complex_editor.ui.main_window import run_gui
 


### PR DESCRIPTION
## Summary
- ensure sys.path bootstrap uses src/ directory
- add defensive bootstrap logic
- insert src/ path before imports in `ui_skeleton.py`
- add namespace package to allow running `python -m complex_editor.cli` from repo root
- document venv reset steps in README

## Testing
- `pytest -q`
- `python -m complex_editor.cli -h`
- `python ui_skeleton.py` *(fails: Could not load Qt platform plugin "xcb" in "" even though it was found)*

------
https://chatgpt.com/codex/tasks/task_e_687659f68394832c902b701ca350ba12