### PR TITLE
Improve handling for GATE defaults

### DIFF
--- a/tests/test_param_page.py
+++ b/tests/test_param_page.py
@@ -140,16 +140,20 @@ def test_param_page_build(qapp, macro_name):
                     widget.setValue(widget.maximum() + 5)
                     assert widget.value() <= widget.maximum()
                 else:
-                    assert isinstance(widget, QtWidgets.QDoubleSpinBox)
-                    if min_v is not None:
-                        assert widget.minimum() == pytest.approx(float(min_v), abs=0.01)
-                    if max_v is not None:
-                        assert widget.maximum() == pytest.approx(float(max_v), abs=0.01)
-                    init = p.default if p.default is not None else min_v
-                    if init is not None:
-                        assert widget.value() == pytest.approx(float(init), abs=0.01)
-                    widget.setValue(widget.maximum() * 2)
-                    assert widget.value() <= widget.maximum()
+                    if macro_name == "GATE" and p.name.startswith("Check_"):
+                        assert isinstance(widget, QtWidgets.QLineEdit)
+                    else:
+                        assert isinstance(widget, QtWidgets.QDoubleSpinBox)
+                    if not isinstance(widget, QtWidgets.QLineEdit):
+                        if min_v is not None:
+                            assert widget.minimum() == pytest.approx(float(min_v), abs=0.01)
+                        if max_v is not None:
+                            assert widget.maximum() == pytest.approx(float(max_v), abs=0.01)
+                        init = p.default if p.default is not None else min_v
+                        if init is not None:
+                            assert widget.value() == pytest.approx(float(init), abs=0.01)
+                        widget.setValue(widget.maximum() * 2)
+                        assert widget.value() <= widget.maximum()
         elif isinstance(spec, list):
             assert isinstance(widget, QtWidgets.QComboBox)
             assert [widget.itemText(i) for i in range(widget.count())] == [

--- a/tests/test_param_validate.py
+++ b/tests/test_param_validate.py
@@ -38,6 +38,7 @@ def test_validation_and_overrides(qtbot):
     wiz.macro_page.macro_combo.setCurrentIndex(idx)
     wiz.macro_page.pin_table.cellWidget(0, 1).setCurrentText("1")
     wiz.macro_page.pin_table.cellWidget(1, 1).setCurrentText("2")
+    wiz._next()
     spin = wiz.param_page.widgets.get("Value")
     assert isinstance(spin, QtWidgets.QSpinBox)
     spin.setValue(1)

--- a/tests/test_wizard_flow.py
+++ b/tests/test_wizard_flow.py
@@ -38,16 +38,16 @@ def test_wizard_flow(qtbot):
     wizard.macro_page.macro_combo.setCurrentIndex(idx)
     wizard.macro_page.pin_table.cellWidget(0, 1).setCurrentText("1")
     wizard.macro_page.pin_table.cellWidget(1, 1).setCurrentText("2")
+    wizard._next()
     val_widget = wizard.param_page.widgets.get("Value")
     if isinstance(val_widget, QtWidgets.QSpinBox):
         val_widget.setValue(10)
     wizard._next()  # save params back to list
     wizard.list_page.list.setCurrentRow(0)
     wizard.list_page.dup_btn.click()
-    wizard._back()
     wizard.macro_page.pin_table.cellWidget(0, 1).setCurrentText("3")
-    wizard._back()
     wizard.macro_page.pin_table.cellWidget(1, 1).setCurrentText("4")
+    wizard._next()
     val_widget2 = wizard.param_page.widgets.get("Value")
     if isinstance(val_widget2, QtWidgets.QSpinBox):
         assert val_widget2.value() == 10


### PR DESCRIPTION
## Summary
- hide `-1` default values in GATE pin fields
- treat `-1` as blank when validating GATE parameters
- skip overrides when GATE pins remain at their `-1` defaults

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest-qt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687751220038832cbfc3b3826d3b8fb5