### PR TITLE
Fix Access join syntax in list_complexes query

### DIFF
--- a/src/complex_editor/db/mdb_api.py
+++ b/src/complex_editor/db/mdb_api.py
@@ -103,8 +103,8 @@ class MDB:
             f"""
             SELECT m.{PK_MASTER}, m.{NAME_COL}, f.Name,
                    COUNT(d.{PK_DETAIL})
-            FROM {MASTER_T} AS m
-            LEFT JOIN {DETAIL_T} AS d ON m.{PK_MASTER}=d.{PK_MASTER}
+            FROM ({MASTER_T} AS m
+                  LEFT JOIN {DETAIL_T} AS d ON m.{PK_MASTER}=d.{PK_MASTER})
             LEFT JOIN {FUNC_T} AS f ON m.IDFunction=f.IDFunction
             GROUP BY m.{PK_MASTER}, m.{NAME_COL}, f.Name
             ORDER BY m.{PK_MASTER}


### PR DESCRIPTION
## Summary
- ensure Access SQL uses parentheses when chaining LEFT JOINs in `list_complexes`

## Testing
- `pytest` *(fails: ImportError: libGL.so.1 cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689ae03d7f80832ca3a6428642536234