### PR TITLE
Fix Access query for list_complexes

### DIFF
--- a/src/complex_editor/db/mdb_api.py
+++ b/src/complex_editor/db/mdb_api.py
@@ -101,12 +101,12 @@ class MDB:
         cur = self._cur()
         cur.execute(
             f"""
-            SELECT m.{PK_MASTER}, m.{NAME_COL}, f.Name,
+            SELECT m.{PK_MASTER}, m.[{NAME_COL}], f.[Name],
                    COUNT(d.{PK_DETAIL})
-            FROM {MASTER_T} AS m
-            LEFT JOIN {DETAIL_T} AS d ON m.{PK_MASTER}=d.{PK_MASTER}
+            FROM ({MASTER_T} AS m
+                  LEFT JOIN {DETAIL_T} AS d ON m.{PK_MASTER}=d.{PK_MASTER})
             LEFT JOIN {FUNC_T} AS f ON m.IDFunction=f.IDFunction
-            GROUP BY m.{PK_MASTER}, m.{NAME_COL}, f.Name
+            GROUP BY m.{PK_MASTER}, m.[{NAME_COL}], f.[Name]
             ORDER BY m.{PK_MASTER}
             """
         )


### PR DESCRIPTION
## Summary
- bracket reserved `Name` columns in `list_complexes` Access SQL to prevent parameter errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ae03d7f80832ca3a6428642536234