### PR TITLE
Add JSON buffer mode for GUI and tests

### DIFF
--- a/src/complex_editor/ui/buffer_loader.py
+++ b/src/complex_editor/ui/buffer_loader.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict, Any
+import json
+
+from .adapters import EditorComplex, EditorMacro
+
+
+def load_editor_complexes_from_buffer(path: str | Path) -> List[EditorComplex]:
+    """Read ``path`` and return a list of :class:`EditorComplex`.
+
+    The buffer JSON is expected to be a list of complexes as produced by
+    ``tools/make_gui_buffer.py``.  Each complex entry should contain ``id``,
+    ``name``, ``pins`` and a ``subcomponents`` list with ``function_name`` and
+    a ``pins`` mapping.  Optional fields like ``id``/``value``/``force_bits`` on
+    subcomponents are attached to the returned :class:`EditorMacro` objects as
+    attributes for convenience.
+    """
+
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        raw = json.load(f)
+
+    result: List[EditorComplex] = []
+    for cx in raw:
+        name = str(cx.get("name", ""))
+        cid = int(cx.get("id", 0) or 0)
+        pins = [str(x) for x in (cx.get("pins") or [])]
+
+        sub_macros: List[EditorMacro] = []
+        for sc in cx.get("subcomponents") or []:
+            macro_name = str(
+                sc.get("function_name") or f"Function {sc.get('id_function', '')}"
+            )
+            pin_map: Dict[str, str] = {}
+            for k, v in (sc.get("pins") or {}).items():
+                if k == "S":
+                    continue  # params XML – not handled yet
+                pin_map[str(k)] = str(v)
+            em = EditorMacro(name=macro_name, pins=pin_map, params={})
+            if sc.get("id") is not None:
+                em.sub_id = sc.get("id")
+            if sc.get("value") is not None:
+                em.value = sc.get("value")
+            if sc.get("force_bits") is not None:
+                em.force_bits = sc.get("force_bits")
+            sub_macros.append(em)
+
+        result.append(
+            EditorComplex(id=cid, name=name, pins=pins, subcomponents=sub_macros)
+        )
+    return result

--- a/tests/test_buffer_loader.py
+++ b/tests/test_buffer_loader.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from complex_editor.ui.buffer_loader import load_editor_complexes_from_buffer
+
+
+def test_load_editor_complexes_from_buffer(tmp_path: Path) -> None:
+    buf = [
+        {
+            "id": 123,
+            "name": "DEMO",
+            "total_pins": 4,
+            "pins": ["1", "2", "3", "4"],
+            "subcomponents": [
+                {
+                    "id": 1,
+                    "id_function": 6,
+                    "function_name": "RESISTOR",
+                    "value": None,
+                    "force_bits": 0,
+                    "pins": {"A": "1", "B": "2"},
+                },
+                {
+                    "id": 2,
+                    "id_function": 16,
+                    "function_name": "RELAIS",
+                    "value": "12.0",
+                    "force_bits": 1,
+                    "pins": {"A": "3", "B": "4"},
+                },
+            ],
+        }
+    ]
+    path = tmp_path / "buffer.json"
+    path.write_text(json.dumps(buf), encoding="utf-8")
+
+    out = load_editor_complexes_from_buffer(path)
+    assert len(out) == 1
+    cx = out[0]
+    assert cx.id == 123
+    assert cx.name == "DEMO"
+    assert cx.pins == ["1", "2", "3", "4"]
+    assert len(cx.subcomponents) == 2
+    assert cx.subcomponents[0].name == "RESISTOR"
+    assert cx.subcomponents[0].pins == {"A": "1", "B": "2"}
+    assert cx.subcomponents[0].params == {}

--- a/tests/test_main_window_buffer.py
+++ b/tests/test_main_window_buffer.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from PyQt6.QtWidgets import QApplication
+from complex_editor.ui.main_window import MainWindow
+
+
+def test_main_window_buffer_mode_populates_tables(qtbot, tmp_path: Path) -> None:
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+    data = [
+        {
+            "id": 42,
+            "name": "RY12",
+            "total_pins": 8,
+            "pins": [str(i) for i in range(1, 9)],
+            "subcomponents": [
+                {
+                    "id": 15806,
+                    "id_function": 16,
+                    "function_name": "RELAIS",
+                    "value": "12.0",
+                    "force_bits": 1,
+                    "pins": {"A": "1", "B": "2", "C": "3", "D": "4"},
+                },
+                {
+                    "id": 15807,
+                    "id_function": 16,
+                    "function_name": "RELAIS",
+                    "value": "12.0",
+                    "force_bits": 1,
+                    "pins": {"A": "1", "B": "2", "C": "6", "D": "7"},
+                },
+            ],
+        }
+    ]
+    buf = tmp_path / "buffer.json"
+    buf.write_text(json.dumps(data), encoding="utf-8")
+
+    app = QApplication.instance() or QApplication([])
+    win = MainWindow(mdb_path=None, buffer_path=buf)
+    qtbot.addWidget(win)
+
+    assert win.list.rowCount() == 1
+    assert win.list.item(0, 0).text() == "42"
+    assert win.list.item(0, 1).text() == "RY12"
+    assert win.list.item(0, 2).text() == "2"
+
+    win.list.selectRow(0)
+    win._on_selected()
+    assert win.sub_table.rowCount() == 2
+    headers = [win.sub_table.horizontalHeaderItem(i).text() for i in range(win.sub_table.columnCount())]
+    assert "Macro" in headers and "Pins" in headers
+
+    row0 = {headers[i]: (win.sub_table.item(0, i).text() if win.sub_table.item(0, i) else "") for i in range(win.sub_table.columnCount())}
+    assert row0["Macro"] == "RELAIS"
+    assert "A=1" in row0["Pins"] and "D=4" in row0["Pins"]

--- a/ui_skeleton.py
+++ b/ui_skeleton.py
@@ -1,5 +1,6 @@
 # ruff: noqa: E402
 
+import argparse
 import pathlib
 import sys
 
@@ -16,5 +17,12 @@ from pathlib import Path
 from complex_editor.ui.main_window import run_gui
 
 if __name__ == "__main__":
-    mdb_file = Path.home() / "Documents" / "ComplexBuilder" / "main_db.mdb"
-    run_gui(mdb_file)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--buffer", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.buffer is not None:
+        run_gui(mdb_file=None, buffer_path=args.buffer)
+    else:
+        mdb_file = Path.home() / "Documents" / "ComplexBuilder" / "main_db.mdb"
+        run_gui(mdb_file)


### PR DESCRIPTION
## Summary
- add EditorComplex/EditorMacro dataclasses and buffer loader
- enable MainWindow to load complexes from JSON buffer when available
- add CLI flag to ui_skeleton.py to launch in buffer mode
- include tests for buffer loader and GUI buffer mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cbe832a60832c8dccbdebb0dc2d60