### PR TITLE
Add PinS macro parameter round-trip support

### DIFF
--- a/src/complex_editor/ui/__init__.py
+++ b/src/complex_editor/ui/__init__.py
@@ -1,4 +1,15 @@
-from .main_window import MainWindow, run_gui
-from .new_complex_wizard import NewComplexWizard
+"""UI package providing lazy access to heavy Qt modules."""
 
 __all__ = ["MainWindow", "run_gui", "NewComplexWizard"]
+
+
+def __getattr__(name):  # pragma: no cover - simple lazy loader
+    if name in {"MainWindow", "run_gui"}:
+        from .main_window import MainWindow, run_gui
+
+        return {"MainWindow": MainWindow, "run_gui": run_gui}[name]
+    if name == "NewComplexWizard":
+        from .new_complex_wizard import NewComplexWizard
+
+        return NewComplexWizard
+    raise AttributeError(name)

--- a/src/complex_editor/ui/buffer_persistence.py
+++ b/src/complex_editor/ui/buffer_persistence.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Helpers for reading and writing the GUI JSON buffer."""
+
+from pathlib import Path
+from typing import Any, List
+import json
+
+
+def load_buffer(path: Path) -> List[dict]:
+    """Load ``path`` and return the list of complexes contained within."""
+
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert isinstance(data, list)
+    return data  # type: ignore[return-value]
+
+
+def save_buffer(path: Path, complexes: List[dict]) -> None:
+    """Write *complexes* to ``path`` in JSON format."""
+
+    p = Path(path)
+    with p.open("w", encoding="utf-8") as f:
+        json.dump(complexes, f, ensure_ascii=False, indent=2)

--- a/src/complex_editor/ui/param_editor.py
+++ b/src/complex_editor/ui/param_editor.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Simple dialog for editing macro parameters."""
+
+from typing import Dict, Mapping
+from PyQt6 import QtWidgets
+
+
+class MacroParamsDialog(QtWidgets.QDialog):
+    """Dialog allowing users to edit a mapping of ``{name: value}`` pairs."""
+
+    def __init__(self, params: Mapping[str, str] | None = None, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Macro Parameters")
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.table = QtWidgets.QTableWidget(0, 2)
+        self.table.setHorizontalHeaderLabels(["Param", "Value"])
+        layout.addWidget(self.table)
+
+        btn_layout = QtWidgets.QHBoxLayout()
+        add_btn = QtWidgets.QPushButton("Add")
+        rm_btn = QtWidgets.QPushButton("Remove")
+        btn_layout.addWidget(add_btn)
+        btn_layout.addWidget(rm_btn)
+        btn_layout.addStretch()
+        layout.addLayout(btn_layout)
+
+        add_btn.clicked.connect(self._add_row)
+        rm_btn.clicked.connect(self._remove_row)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        if params:
+            self.set_params(dict(params))
+
+    # ------------------------------------------------------------------ helpers
+    def set_params(self, params: Dict[str, str]) -> None:
+        self.table.setRowCount(0)
+        for key, val in params.items():
+            r = self.table.rowCount()
+            self.table.insertRow(r)
+            self.table.setItem(r, 0, QtWidgets.QTableWidgetItem(str(key)))
+            self.table.setItem(r, 1, QtWidgets.QTableWidgetItem(str(val)))
+
+    def params(self) -> Dict[str, str]:
+        result: Dict[str, str] = {}
+        for r in range(self.table.rowCount()):
+            k_item = self.table.item(r, 0)
+            v_item = self.table.item(r, 1)
+            key = k_item.text().strip() if k_item else ""
+            val = v_item.text() if v_item else ""
+            if key:
+                result[key] = val
+        return result
+
+    # ----------------------------------------------------------------- callbacks
+    def _add_row(self) -> None:
+        self.table.insertRow(self.table.rowCount())
+
+    def _remove_row(self) -> None:
+        row = self.table.currentRow()
+        if row >= 0:
+            self.table.removeRow(row)

--- a/src/complex_editor/utils/macro_xml_translator.py
+++ b/src/complex_editor/utils/macro_xml_translator.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""Utility functions for converting between PinS macro XML and dictionaries.
+
+This module exposes helpers to decode and encode the XML blobs stored in the
+``S`` pin of sub–components.  The functions are intentionally small and do not
+have any dependency on the rest of the project so they can be reused by the GUI
+as well as command line tools.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+import xml.etree.ElementTree as ET
+import yaml
+
+
+def _ensure_text(data: bytes | str) -> str:
+    """Return *data* as text.
+
+    Parameters
+    ----------
+    data:
+        Bytes or string containing XML.  Various encodings used by legacy
+        tools are tolerated (``utf-16``, ``utf-16-le`` and ``utf-8``).
+    """
+
+    if isinstance(data, str):
+        return data
+    for enc in ("utf-16", "utf-16-le", "utf-8"):
+        try:
+            return data.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    # Last resort – decode as utf-8 with replacement to avoid raising.
+    return data.decode("utf-8", errors="replace")
+
+
+def xml_to_params(xml: bytes | str) -> Dict[str, Dict[str, str]]:
+    """Parse the ``PinS`` XML blob into a nested mapping.
+
+    The returned mapping has the shape ``{MacroName: {ParamName: Value}}``.
+    If *xml* is empty or malformed an empty dictionary is returned.
+    """
+
+    text = _ensure_text(xml).strip()
+    if not text:
+        return {}
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError:
+        return {}
+    macros_elem = root.find("Macros")
+    result: Dict[str, Dict[str, str]] = {}
+    if macros_elem is None:
+        return result
+    for macro in macros_elem.findall("Macro"):
+        mname = macro.get("Name", "")
+        params: Dict[str, str] = {}
+        for param in macro.findall("Param"):
+            pname = param.get("Name", "")
+            pval = param.get("Value", "")
+            params[pname] = pval
+        result[mname] = params
+    return result
+
+
+def params_to_xml(
+    macros: Mapping[str, Mapping[str, Any]],
+    *,
+    encoding: str = "utf-16",
+    schema: Optional[Mapping[str, Mapping[str, Any]]] = None,
+) -> bytes:
+    """Serialize *macros* into the ``PinS`` XML format.
+
+    ``macros`` is expected to be a mapping of ``{MacroName: {ParamName: Value}}``.
+    The output always contains an XML declaration and is encoded using
+    ``encoding`` (``utf-16`` by default for compatibility with legacy tools).
+
+    The optional ``schema`` parameter may contain validation/coercion rules, but
+    it is currently only a placeholder and values are written verbatim.
+    """
+
+    root = ET.Element("R")
+    macros_el = ET.SubElement(root, "Macros")
+    for mname, params in macros.items():
+        m_el = ET.SubElement(macros_el, "Macro", {"Name": str(mname)})
+        for pname, value in (params or {}).items():
+            ET.SubElement(
+                m_el,
+                "Param",
+                {"Name": str(pname), "Value": "" if value is None else str(value)},
+            )
+    return ET.tostring(root, encoding=encoding, xml_declaration=True)
+
+
+def load_schema(path: str | Path) -> Mapping[str, Any]:
+    """Load a YAML schema file if one is provided.
+
+    The schema is optional and is primarily intended for future validation of
+    parameter values.  This function simply returns the loaded mapping and will
+    raise ``OSError``/``yaml.YAMLError`` if the file cannot be read.
+    """
+
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}

--- a/tests/test_adapters_params.py
+++ b/tests/test_adapters_params.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os, sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from complex_editor.ui.adapters import to_editor_model
+from complex_editor.utils.macro_xml_translator import params_to_xml
+
+
+def test_adapter_populates_macro_params() -> None:
+    macros = {"RELAIS": {"PowerCoil": "0"}, "ALT": {"Foo": "1"}}
+    xml = params_to_xml(macros).decode("utf-16")
+    sc = SimpleNamespace(id_function=16, pins={"A": "1", "B": "2", "S": xml})
+    cx = SimpleNamespace(
+        total_pins=2, subcomponents=[sc], id_comp_desc=1, name="CX"
+    )
+    db = SimpleNamespace(list_functions=lambda: [(16, "RELAIS")])
+
+    model = to_editor_model(db, cx)
+    assert len(model.subcomponents) == 1
+    sub = model.subcomponents[0]
+    assert sub.selected_macro == "RELAIS"
+    assert sub.macro_params == {"PowerCoil": "0"}
+    assert "ALT" in sub.all_macros
+
+    sub.selected_macro = "ALT"
+    sub.macro_params = sub.all_macros["ALT"]
+    assert sub.macro_params == {"Foo": "1"}

--- a/tests/test_buffer_persistence.py
+++ b/tests/test_buffer_persistence.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import os, sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from complex_editor.ui.buffer_persistence import load_buffer, save_buffer
+from complex_editor.utils.macro_xml_translator import xml_to_params, params_to_xml
+
+
+def test_buffer_roundtrip(tmp_path: Path) -> None:
+    macros = {"RELAIS": {"PowerCoil": "0"}}
+    xml = params_to_xml(macros).decode("utf-16")
+    data = [
+        {
+            "id": 1,
+            "name": "CX",
+            "total_pins": 2,
+            "pins": ["1", "2"],
+            "subcomponents": [
+                {
+                    "id": 1,
+                    "id_function": 16,
+                    "function_name": "RELAIS",
+                    "pins": {"A": "1", "B": "2", "S": xml},
+                }
+            ],
+        }
+    ]
+    path = tmp_path / "buffer.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    loaded = load_buffer(path)
+    macros_loaded = xml_to_params(loaded[0]["subcomponents"][0]["pins"]["S"])
+    assert macros_loaded["RELAIS"]["PowerCoil"] == "0"
+    macros_loaded["RELAIS"]["PowerCoil"] = "1"
+    loaded[0]["subcomponents"][0]["pins"]["S"] = params_to_xml(macros_loaded).decode(
+        "utf-16"
+    )
+    save_buffer(path, loaded)
+
+    again = load_buffer(path)
+    macros_again = xml_to_params(again[0]["subcomponents"][0]["pins"]["S"])
+    assert macros_again["RELAIS"]["PowerCoil"] == "1"

--- a/tests/test_macro_xml_translator.py
+++ b/tests/test_macro_xml_translator.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from complex_editor.utils.macro_xml_translator import xml_to_params, params_to_xml
+
+
+def test_parse_sample_pins_s() -> None:
+    sample = (
+        '<?xml version="1.0" encoding="utf-16"?>\n'
+        '<R><Macros><Macro Name="RELAIS">'
+        '<Param Name="PowerCoil" Value="0"/>'
+        '</Macro></Macros></R>'
+    ).encode("utf-16")
+    params = xml_to_params(sample)
+    assert "RELAIS" in params
+    assert params["RELAIS"]["PowerCoil"] == "0"
+
+
+def test_roundtrip_utf16() -> None:
+    macros = {"RELAIS": {"PowerCoil": "0"}, "ALT": {"Foo": "1"}}
+    xml = params_to_xml(macros)
+    parsed = xml_to_params(xml)
+    assert parsed == macros


### PR DESCRIPTION
## Summary
- add XML<->params translator for PinS macros
- surface macro params in editor models and buffer loaders
- add buffer JSON persistence and GUI hooks for macro editing
- include dialog to edit macro parameters
- tests for translator, adapters and buffer round-trip

## Testing
- `pytest tests/test_macro_xml_translator.py tests/test_adapters_params.py tests/test_buffer_persistence.py -q`
- `pytest -q` *(fails: ....E.....E......EEE.............................)*

------
https://chatgpt.com/codex/tasks/task_e_689ddbbe0184832c9184208be4d0a0e3