### PR TITLE
Enable PinS parameter preload and wizard navigation

### DIFF
--- a/src/complex_editor/io/buffer_loader.py
+++ b/src/complex_editor/io/buffer_loader.py
@@ -26,6 +26,7 @@ class BufferSubComponent:
     macro_name: Optional[str]
     pin_map: Dict[str, str]
     pin_s: Optional[str] = None
+    value: Optional[str] = None
 
 
 @dataclass
@@ -97,6 +98,7 @@ def load_complex_from_buffer_json(path: str | Path) -> BufferComplex:
 
         pin_map: Dict[str, str] = {}
         s_xml: Optional[str] = None
+        value = entry.get("Value") or entry.get("value")
         raw_pins = entry.get("PinMap") or entry.get("Pins")
         if isinstance(raw_pins, dict):
             for k, v in raw_pins.items():
@@ -125,6 +127,7 @@ def load_complex_from_buffer_json(path: str | Path) -> BufferComplex:
                 macro_name=str(macro_name) if macro_name is not None else None,
                 pin_map=pin_map,
                 pin_s=s_xml,
+                value=str(value) if value not in (None, "") else None,
             )
         )
 
@@ -192,6 +195,7 @@ def to_wizard_prefill(
                 "name": sc.name,
                 "refdes": sc.refdes,
                 "pins_s": sc.pin_s,
+                "value": sc.value,
             }
         )
 

--- a/src/complex_editor/io/db_adapter.py
+++ b/src/complex_editor/io/db_adapter.py
@@ -62,6 +62,7 @@ def to_wizard_prefill_from_db(
                 "id_function": id_function,
                 "pins": pins,
                 "pins_s": raw_pins.get("S"),
+                "value": getattr(sc, "value", None),
             }
         )
 

--- a/src/complex_editor/ui/main_window.py
+++ b/src/complex_editor/ui/main_window.py
@@ -291,7 +291,10 @@ class MainWindow(QtWidgets.QMainWindow):
         prefill = to_wizard_prefill_from_db(
             raw, self._macro_id_from_name, self._pin_normalizer
         )
-        wiz = NewComplexWizard.from_existing(prefill, cid, parent=self)
+        title = getattr(raw, "name", None)
+        wiz = NewComplexWizard.from_existing(
+            prefill, cid, parent=self, title=title or "New Complex"
+        )
 
         if wiz.exec() == QtWidgets.QDialog.DialogCode.Accepted:
             from ..db.mdb_api import SubComponent as DbSubComponent, ComplexDevice as DbComplex

--- a/src/complex_editor/ui/widgets/step_indicator.py
+++ b/src/complex_editor/ui/widgets/step_indicator.py
@@ -2,23 +2,27 @@ from __future__ import annotations
 
 from typing import List
 
-from PyQt6 import QtWidgets
+from PyQt6 import QtWidgets, QtCore
 
 
 class StepIndicator(QtWidgets.QWidget):
     """Simple horizontal step indicator used by the wizard."""
 
+    step_clicked = QtCore.pyqtSignal(int)
+
     def __init__(self, steps: List[str], parent=None) -> None:
         super().__init__(parent)
-        self._labels: List[QtWidgets.QLabel] = []
+        self._labels: List[QtWidgets.QPushButton] = []
         self._current = -1
         layout = QtWidgets.QHBoxLayout(self)
         layout.setSpacing(4)
-        for name in steps:
-            lbl = QtWidgets.QLabel(name)
-            lbl.setStyleSheet("padding:4px;border:1px solid #888;")
-            layout.addWidget(lbl)
-            self._labels.append(lbl)
+        for idx, name in enumerate(steps):
+            btn = QtWidgets.QPushButton(name)
+            btn.setFlat(True)
+            btn.setStyleSheet("padding:4px;border:1px solid #888;")
+            btn.clicked.connect(lambda _=False, i=idx: self.step_clicked.emit(i))
+            layout.addWidget(btn)
+            self._labels.append(btn)
         layout.addStretch()
         self.set_current(0)
 

--- a/tests/ui/test_param_save_roundtrip.py
+++ b/tests/ui/test_param_save_roundtrip.py
@@ -1,0 +1,40 @@
+import os, sys, types
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from PyQt6 import QtWidgets  # noqa: E402
+from complex_editor.ui.new_complex_wizard import NewComplexWizard  # noqa: E402
+from complex_editor.io.buffer_loader import WizardPrefill  # noqa: E402
+from complex_editor.util.macro_xml_translator import params_to_xml, xml_to_params  # noqa: E402
+from complex_editor.param_spec import ALLOWED_PARAMS  # noqa: E402
+
+
+def test_param_save_roundtrip(qtbot):
+    macros = {
+        "POWER_CHECK": {"Value": "7", "TolPos": "20", "TolNeg": "20"},
+        "OTHER": {"Foo": "1"},
+    }
+    xml = params_to_xml(macros, encoding="utf-16", schema=ALLOWED_PARAMS).decode("utf-16")
+    prefill = WizardPrefill(
+        complex_name="X",
+        sub_components=[{"macro_name": "POWER_CHECK", "pins": [1], "pins_s": xml}],
+    )
+    wiz = NewComplexWizard.from_wizard_prefill(prefill)
+    qtbot.addWidget(wiz)
+    wiz.activate_pin_mapping_for(0)
+    wiz._open_param_page()
+    val_widget = wiz.param_page.widgets.get("Value")
+    assert isinstance(val_widget, QtWidgets.QSpinBox)
+    val_widget.setValue(8)
+    wiz._save_params()
+    sc = wiz.sub_components[0]
+    new_xml = getattr(sc, "pin_s")
+    parsed = xml_to_params(new_xml)
+    assert parsed["POWER_CHECK"]["Value"] == "8"
+    assert "OTHER" in parsed and parsed["OTHER"]["Foo"] == "1"

--- a/tests/ui/test_pins_preload_buffer.py
+++ b/tests/ui/test_pins_preload_buffer.py
@@ -1,0 +1,66 @@
+import os, sys, types
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from complex_editor.io.buffer_loader import load_complex_from_buffer_json, to_wizard_prefill  # noqa: E402
+from complex_editor.ui.new_complex_wizard import NewComplexWizard  # noqa: E402
+from complex_editor.util.macro_xml_translator import xml_to_params, params_to_xml  # noqa: E402
+from complex_editor.param_spec import ALLOWED_PARAMS  # noqa: E402
+from PyQt6 import QtWidgets  # noqa: E402
+
+
+def _resolver(name: str):
+    return {"DIODE": 3}.get(name.upper())
+
+
+def _normalizer(pin_map):
+    return pin_map
+
+
+@pytest.mark.parametrize("remove_value", [False, True])
+def test_pins_preload_buffer(qtbot, remove_value):
+    path = Path(__file__).resolve().parents[2] / "tools" / "buffer.json"
+    buf = load_complex_from_buffer_json(path)
+    pre = to_wizard_prefill(buf, _resolver, _normalizer)
+
+    target = None
+    xml_value = None
+    for sc in pre.sub_components:
+        s_xml = sc.get("pins_s")
+        if not s_xml or sc.get("value") in (None, ""):
+            continue
+        macros = xml_to_params(s_xml)
+        params = macros.get(sc["macro_name"], {}) if sc.get("macro_name") else {}
+        if any(k.lower() == "value" for k in params):
+            target = sc
+            xml_value = params[next(k for k in params if k.lower() == "value")]
+            break
+    assert target is not None
+    if remove_value:
+        macros = xml_to_params(target["pins_s"])
+        macros[target["macro_name"]].pop("Value", None)
+        target = dict(target)
+        target["pins_s"] = params_to_xml(macros, encoding="utf-16", schema=ALLOWED_PARAMS).decode("utf-16")
+    prefill = type(pre)(complex_name=pre.complex_name, sub_components=[target])
+
+    wiz = NewComplexWizard.from_wizard_prefill(prefill)
+    qtbot.addWidget(wiz)
+    wiz.activate_pin_mapping_for(0)
+    wiz._open_param_page()
+    val_widget = wiz.param_page.widgets.get("Value")
+    assert val_widget is not None
+    if isinstance(val_widget, QtWidgets.QSpinBox):
+        val = val_widget.value()
+    else:
+        val = float(val_widget.text())
+    if remove_value:
+        assert pytest.approx(val, rel=1e-6) == float(target.get("value"))
+    else:
+        assert pytest.approx(val, rel=1e-6) == float(xml_value)
+    assert wiz.param_page.warn_label.isHidden()

--- a/tests/ui/test_power_check_default.py
+++ b/tests/ui/test_power_check_default.py
@@ -1,0 +1,35 @@
+import os, sys, types
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from complex_editor.io.buffer_loader import WizardPrefill  # noqa: E402
+from complex_editor.ui.new_complex_wizard import NewComplexWizard  # noqa: E402
+from complex_editor.util.macro_xml_translator import params_to_xml, xml_to_params  # noqa: E402
+from complex_editor.param_spec import ALLOWED_PARAMS  # noqa: E402
+from PyQt6 import QtWidgets  # noqa: E402
+
+
+def test_power_check_default(qtbot):
+    macros = {"POWER_CHECK": {"Value": "Default", "TolPos": "Default"}}
+    xml = params_to_xml(macros, encoding="utf-16", schema=ALLOWED_PARAMS).decode("utf-16")
+    prefill = WizardPrefill(
+        complex_name="X",
+        sub_components=[{"macro_name": "POWER_CHECK", "pins": [1, 2], "pins_s": xml}],
+    )
+    wiz = NewComplexWizard.from_wizard_prefill(prefill)
+    qtbot.addWidget(wiz)
+    wiz.activate_pin_mapping_for(0)
+    wiz._open_param_page()
+    val_widget = wiz.param_page.widgets.get("Value")
+    assert isinstance(val_widget, QtWidgets.QSpinBox)
+    assert val_widget.value() == 0
+    wiz._save_params()
+    sc = wiz.sub_components[0]
+    parsed = xml_to_params(getattr(sc, "pin_s"))
+    assert parsed["POWER_CHECK"]["Value"] == "0"

--- a/tests/ui/test_step_indicator_navigation.py
+++ b/tests/ui/test_step_indicator_navigation.py
@@ -1,0 +1,38 @@
+import os, sys, types
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from complex_editor.ui.new_complex_wizard import NewComplexWizard  # noqa: E402
+from complex_editor.db.schema_introspect import discover_macro_map  # noqa: E402
+
+
+class FakeCursorNoTables:
+    def tables(self, table=None, tableType=None):
+        if False:
+            yield
+
+    def columns(self, table):
+        raise AssertionError
+
+    def execute(self, query):
+        raise AssertionError
+
+
+def test_step_indicator_navigation(qtbot):
+    macro_map = discover_macro_map(FakeCursorNoTables())
+    wiz = NewComplexWizard(macro_map)
+    qtbot.addWidget(wiz)
+    # start on basics
+    assert wiz.step_indicator.current_index == 0
+    # click to subcomponents
+    wiz.step_indicator._labels[1].click()
+    assert wiz.stack.currentWidget() is wiz.list_page
+    assert wiz.step_indicator.current_index == 1
+    # click to review
+    wiz.step_indicator._labels[3].click()
+    assert wiz.stack.currentWidget() is wiz.review_page
+    assert wiz.step_indicator.current_index == 3

--- a/tests/ui/test_wizard_title.py
+++ b/tests/ui/test_wizard_title.py
@@ -1,0 +1,21 @@
+import os, sys, types
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from complex_editor.ui.new_complex_wizard import NewComplexWizard  # noqa: E402
+
+
+def test_wizard_title_default(qtbot):
+    wiz = NewComplexWizard(None)
+    qtbot.addWidget(wiz)
+    assert wiz.windowTitle() == "New Complex"
+
+
+def test_wizard_title_custom(qtbot):
+    wiz = NewComplexWizard(None, title="LM358M")
+    qtbot.addWidget(wiz)
+    assert wiz.windowTitle() == "LM358M"


### PR DESCRIPTION
## Summary
- preload and persist PinS macro parameters, including value field, using xml translator
- add optional wizard title and clickable step indicator
- safely coerce numeric parameter values and honour schema defaults

## Testing
- `pytest tests/ui/test_wizard_title.py -q`
- `pytest tests/ui/test_step_indicator_navigation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e059c3614832c99499f15573d7f5c