### PR TITLE
Fix parameter validation for Default and enum types

### DIFF
--- a/tests/test_param_default_sentinel_roundtrip.py
+++ b/tests/test_param_default_sentinel_roundtrip.py
@@ -1,0 +1,18 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+from complex_editor.util.macro_xml_translator import xml_to_params, params_to_xml
+
+
+def test_param_default_sentinel_roundtrip() -> None:
+    xml = (
+        '<?xml version="1.0" encoding="utf-16"?>'
+        '<R><Macros>'
+        '<Macro Name="POWER_CHECK"><Param Name="Value" Value="Default"/></Macro>'
+        '</Macros></R>'
+    ).encode('utf-16')
+    params = xml_to_params(xml)
+    assert params['POWER_CHECK']['Value'] == 'Default'
+    rebuilt = params_to_xml(params)
+    again = xml_to_params(rebuilt)
+    assert again['POWER_CHECK']['Value'] == 'Default'

--- a/tests/ui/test_param_validation_modes.py
+++ b/tests/ui/test_param_validation_modes.py
@@ -1,0 +1,54 @@
+import os, sys, types
+from pathlib import Path
+import os, sys, types
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.modules.setdefault("pyodbc", types.ModuleType("pyodbc"))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from PyQt6 import QtWidgets  # noqa: E402
+from complex_editor.io.buffer_loader import WizardPrefill  # noqa: E402
+from complex_editor.ui.new_complex_wizard import NewComplexWizard  # noqa: E402
+from complex_editor.util.macro_xml_translator import params_to_xml, xml_to_params  # noqa: E402
+from complex_editor.param_spec import ALLOWED_PARAMS  # noqa: E402
+
+
+def _make_wizard(macro, params, qtbot):
+    xml = params_to_xml({macro: params}, encoding="utf-16", schema=ALLOWED_PARAMS).decode("utf-16")
+    prefill = WizardPrefill(
+        complex_name="X",
+        sub_components=[{"macro_name": macro, "pins": [1], "pins_s": xml}],
+    )
+    wiz = NewComplexWizard.from_wizard_prefill(prefill)
+    qtbot.addWidget(wiz)
+    wiz.activate_pin_mapping_for(0)
+    wiz._open_param_page()
+    return wiz
+
+
+def test_enum_validation(qtbot):
+    wiz = _make_wizard("VOLTAGEREGULATOR", {"PowerSet": "OFF"}, qtbot)
+    assert not wiz.param_page.errors
+
+
+def test_default_numeric_validation(qtbot):
+    wiz = _make_wizard("POWER_CHECK", {"Value": "Default", "TestResult": "Default"}, qtbot)
+    assert not wiz.param_page.errors
+    wiz._save_params()
+    params = xml_to_params(wiz.sub_components[0].pin_s)
+    assert params["POWER_CHECK"]["Value"] == "Default"
+    assert params["POWER_CHECK"]["TestResult"] == "Default"
+
+
+def test_numeric_range_error(qtbot):
+    wiz = _make_wizard("FAN", {"TolPosI": "500"}, qtbot)
+    w = wiz.param_page.widgets.get("TolPosI")
+    assert isinstance(w, QtWidgets.QSpinBox)
+    w.setMaximum(5000)
+    w.setValue(2000)
+    wiz.param_page._validate()
+    assert any("TolPosI" in err for err in wiz.param_page.errors)

--- a/tests/ui/test_power_check_default.py
+++ b/tests/ui/test_power_check_default.py
@@ -16,7 +16,7 @@ from PyQt6 import QtWidgets  # noqa: E402
 
 
 def test_power_check_default(qtbot):
-    macros = {"POWER_CHECK": {"Value": "Default", "TolPos": "Default"}}
+    macros = {"POWER_CHECK": {"Value": "Default", "TestResult": "Default"}}
     xml = params_to_xml(macros, encoding="utf-16", schema=ALLOWED_PARAMS).decode("utf-16")
     prefill = WizardPrefill(
         complex_name="X",
@@ -28,11 +28,13 @@ def test_power_check_default(qtbot):
     wiz._open_param_page()
     val_widget = wiz.param_page.widgets.get("Value")
     assert isinstance(val_widget, QtWidgets.QSpinBox)
-    assert val_widget.value() == 0
+    assert "Value" in wiz.param_page.special_values
     enum_widget = wiz.param_page.widgets.get("TestResult")
     assert isinstance(enum_widget, QtWidgets.QComboBox)
     assert enum_widget.currentText() == "Default"
+    assert not wiz.param_page.errors
     wiz._save_params()
     sc = wiz.sub_components[0]
     parsed = xml_to_params(getattr(sc, "pin_s"))
-    assert parsed["POWER_CHECK"]["Value"] == "0"
+    assert parsed["POWER_CHECK"]["Value"] == "Default"
+    assert parsed["POWER_CHECK"]["TestResult"] == "Default"


### PR DESCRIPTION
## Summary
- handle case-insensitive macro/param lookups and preserve "Default" sentinel values
- skip numeric range checks for enum or "Default" selections
- add tests covering default roundtrip and validation cases

## Testing
- `pytest tests/test_param_default_sentinel_roundtrip.py tests/ui/test_param_validation_modes.py tests/ui/test_power_check_default.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689e1d86b274832ca72d345344c8488b