### PR TITLE
Skip default macro parameters and validate GATE checks

### DIFF
--- a/tests/test_macro_xml_translator.py
+++ b/tests/test_macro_xml_translator.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import os, sys
+import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
+from complex_editor.param_spec import ALLOWED_PARAMS
 from complex_editor.util.macro_xml_translator import xml_to_params, params_to_xml
 
 
@@ -23,3 +25,21 @@ def test_roundtrip_utf16() -> None:
     xml = params_to_xml(macros)
     parsed = xml_to_params(xml)
     assert parsed == macros
+
+
+def test_params_to_xml_skips_defaults() -> None:
+    macros = {"FAN": {"BurstNr": "0", "StartFreq": "0", "StopFreq": "50000"}}
+    xml = params_to_xml(macros, schema=ALLOWED_PARAMS)
+    text = xml.decode("utf-16")
+    assert "BurstNr" not in text
+    assert "StartFreq" not in text
+    assert '<Param Name="StopFreq" Value="50000"' in text
+
+
+def test_gate_check_length_validation() -> None:
+    with pytest.raises(ValueError):
+        params_to_xml({"GATE": {"PathPin_A": "0101", "Check_A": "11"}})
+    xml = params_to_xml({"GATE": {"PathPin_A": "0101", "Check_A": "1111"}})
+    assert '<Param Name="Check_A" Value="1111"' in xml.decode("utf-16")
+    xml2 = params_to_xml({"GATE": {"PathPin_A": "0101"}})
+    assert "Check_A" not in xml2.decode("utf-16")

--- a/tests/test_param_default_sentinel_roundtrip.py
+++ b/tests/test_param_default_sentinel_roundtrip.py
@@ -15,4 +15,4 @@ def test_param_default_sentinel_roundtrip() -> None:
     assert params['POWER_CHECK']['Value'] == 'Default'
     rebuilt = params_to_xml(params)
     again = xml_to_params(rebuilt)
-    assert again['POWER_CHECK']['Value'] == 'Default'
+    assert 'Value' not in again['POWER_CHECK']

--- a/tests/ui/test_param_validation_modes.py
+++ b/tests/ui/test_param_validation_modes.py
@@ -40,8 +40,7 @@ def test_default_numeric_validation(qtbot):
     assert not wiz.param_page.errors
     wiz._save_params()
     params = xml_to_params(wiz.sub_components[0].pin_s)
-    assert params["POWER_CHECK"]["Value"] == "Default"
-    assert params["POWER_CHECK"]["TestResult"] == "Default"
+    assert params["POWER_CHECK"] == {}
 
 
 def test_numeric_range_error(qtbot):

--- a/tests/ui/test_power_check_default.py
+++ b/tests/ui/test_power_check_default.py
@@ -28,7 +28,6 @@ def test_power_check_default(qtbot):
     wiz._open_param_page()
     val_widget = wiz.param_page.widgets.get("Value")
     assert isinstance(val_widget, QtWidgets.QSpinBox)
-    assert "Value" in wiz.param_page.special_values
     enum_widget = wiz.param_page.widgets.get("TestResult")
     assert isinstance(enum_widget, QtWidgets.QComboBox)
     assert enum_widget.currentText() == "Default"
@@ -36,5 +35,4 @@ def test_power_check_default(qtbot):
     wiz._save_params()
     sc = wiz.sub_components[0]
     parsed = xml_to_params(getattr(sc, "pin_s"))
-    assert parsed["POWER_CHECK"]["Value"] == "Default"
-    assert parsed["POWER_CHECK"]["TestResult"] == "Default"
+    assert parsed["POWER_CHECK"] == {}


### PR DESCRIPTION
## Summary
- omit parameters at their default values when serializing macro XML
- validate GATE macro `Check_[A-D]` lengths against corresponding `PathPin` values
- add tests for default filtering and GATE validation

## Testing
- `pytest tests/test_macro_xml_translator.py tests/test_param_default_sentinel_roundtrip.py tests/ui/test_power_check_default.py tests/ui/test_param_validation_modes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a03780f64c832c8ca1a5d03aa9da3c