### PR TITLE
Show PinS XML in main window and skip default macro params

### DIFF
--- a/src/complex_editor/cli.py
+++ b/src/complex_editor/cli.py
@@ -13,9 +13,9 @@ from .db import (
     table_exists,
 )
 from .domain import ComplexDevice, MacroInstance
-from .domain.pinxml import MacroInstance as PinMacroInstance
-from .domain.pinxml import PinXML
 from .services import insert_complex
+from .util.macro_xml_translator import params_to_xml
+from .param_spec import ALLOWED_PARAMS
 
 
 def list_complexes_cmd(args: argparse.Namespace) -> int:
@@ -69,8 +69,7 @@ def make_pinxml_cmd(args: argparse.Namespace) -> int:
             return 1
         name, value = item.split("=", 1)
         params_pairs.append((name, value))
-    macro = PinMacroInstance(args.macro, dict(params_pairs))
-    xml_blob = PinXML.serialize([macro])
+    xml_blob = params_to_xml({args.macro: dict(params_pairs)}, encoding="utf-16", schema=ALLOWED_PARAMS)
     hex_dump = " ".join(f"{b:02x}" for b in xml_blob)
     print(hex_dump)
     return 0

--- a/src/complex_editor/data/mdb_writer.py
+++ b/src/complex_editor/data/mdb_writer.py
@@ -4,7 +4,8 @@ from typing import List
 
 import pyodbc
 
-from complex_editor.domain.pinxml import MacroInstance, PinXML
+from complex_editor.util.macro_xml_translator import params_to_xml
+from complex_editor.param_spec import ALLOWED_PARAMS
 
 
 class MdbWriter:
@@ -34,9 +35,8 @@ class MdbWriter:
         sub_id: int,
         macros: List[dict],  # [{'name': …, 'params': {...}}, …]
     ) -> None:
-        xml_blob = PinXML.serialize(
-            [MacroInstance(m["name"], m["params"]) for m in macros]
-        )
+        macro_map = {m["name"]: m.get("params", {}) for m in macros}
+        xml_blob = params_to_xml(macro_map, encoding="utf-16", schema=ALLOWED_PARAMS)
 
         cursor = conn.cursor()
         cursor.execute(

--- a/src/complex_editor/io/buffer_loader.py
+++ b/src/complex_editor/io/buffer_loader.py
@@ -102,10 +102,11 @@ def load_complex_from_buffer_json(path: str | Path) -> BufferComplex:
         raw_pins = entry.get("PinMap") or entry.get("Pins")
         if isinstance(raw_pins, dict):
             for k, v in raw_pins.items():
-                if str(k) == "S":
+                key = str(k)
+                if key in {"S", "PinS"}:
                     s_xml = str(v)
                 else:
-                    pin_map[str(k)] = str(v)
+                    pin_map[key] = str(v)
         else:
             for key, val in entry.items():
                 if not key:

--- a/src/complex_editor/services/export_service.py
+++ b/src/complex_editor/services/export_service.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from ..db import table_exists
 from ..domain import ComplexDevice
-from ..domain.pinxml import MacroInstance as PinMacroInstance
-from ..domain.pinxml import PinXML
+from ..util.macro_xml_translator import params_to_xml
+from ..param_spec import ALLOWED_PARAMS
 
 
 def insert_complex(conn, complex_dev: ComplexDevice) -> int:
@@ -17,8 +17,10 @@ def insert_complex(conn, complex_dev: ComplexDevice) -> int:
     max_id = row[0] if row and row[0] is not None else 0
     next_id = max_id + 1
 
-    pin_s = PinXML.serialize(
-        [PinMacroInstance(complex_dev.macro.name, complex_dev.macro.params)]
+    pin_s = params_to_xml(
+        {complex_dev.macro.name: complex_dev.macro.params},
+        encoding="utf-16",
+        schema=ALLOWED_PARAMS,
     )
     if len(complex_dev.pins) < 2:
         raise ValueError("At least two pins required")

--- a/src/complex_editor/ui/adapters.py
+++ b/src/complex_editor/ui/adapters.py
@@ -11,7 +11,7 @@ read-only and side-effect free.
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, TYPE_CHECKING
 
-from ..util.macro_xml_translator import xml_to_params
+from ..util.macro_xml_translator import xml_to_params, _ensure_text
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from ..db.mdb_api import MDB, ComplexDevice, SubComponent
@@ -33,6 +33,7 @@ class EditorMacro:
     macro_params: Dict[str, str] = field(default_factory=dict)
     all_macros: Dict[str, Dict[str, str]] = field(default_factory=dict)
     pin_s_error: bool = False
+    pin_s_raw: str = ""
 
 
 @dataclass
@@ -83,8 +84,10 @@ def to_editor_model(db: "MDB", cx_db: "ComplexDevice") -> EditorComplex:
         selected_macro = fname
         macro_params: Dict[str, str] = {}
         pin_s_error = False
+        pin_s_raw = ""
         s_xml = (sc.pins or {}).get("S") if getattr(sc, "pins", None) else None
         if s_xml:
+            pin_s_raw = _ensure_text(s_xml)
             try:
                 all_macros = xml_to_params(s_xml)
             except Exception:
@@ -109,6 +112,7 @@ def to_editor_model(db: "MDB", cx_db: "ComplexDevice") -> EditorComplex:
             macro_params=macro_params,
             all_macros=all_macros,
             pin_s_error=pin_s_error,
+            pin_s_raw=pin_s_raw,
         )
         # attach optional attributes used by the editor table
         if getattr(sc, "id_sub_component", None) is not None:

--- a/src/complex_editor/ui/buffer_loader.py
+++ b/src/complex_editor/ui/buffer_loader.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any
 import json
 
 from .adapters import EditorComplex, EditorMacro
-from ..util.macro_xml_translator import xml_to_params
+from ..util.macro_xml_translator import xml_to_params, _ensure_text
 
 
 def load_editor_complexes_from_buffer(path: str | Path) -> List[EditorComplex]:
@@ -46,7 +46,9 @@ def load_editor_complexes_from_buffer(path: str | Path) -> List[EditorComplex]:
             selected_macro = macro_name
             macro_params: Dict[str, str] = {}
             pin_s_error = False
+            pin_s_raw = ""
             if s_xml:
+                pin_s_raw = _ensure_text(s_xml)
                 try:
                     all_macros = xml_to_params(s_xml)
                 except Exception:
@@ -71,6 +73,7 @@ def load_editor_complexes_from_buffer(path: str | Path) -> List[EditorComplex]:
                 macro_params=macro_params,
                 all_macros=all_macros,
                 pin_s_error=pin_s_error,
+                pin_s_raw=pin_s_raw,
             )
             if sc.get("id") is not None:
                 em.sub_id = sc.get("id")

--- a/tests/test_macro_params_dialog_spinbox.py
+++ b/tests/test_macro_params_dialog_spinbox.py
@@ -1,0 +1,25 @@
+import pytest
+from PyQt6 import QtWidgets, QtCore, QtGui
+from complex_editor.ui.param_editor import MacroParamsDialog
+
+
+def test_macro_params_dialog_spinbox_allows_float_and_wheel(qtbot):
+    dlg = MacroParamsDialog({"Value": "1.5"})
+    qtbot.addWidget(dlg)
+    spin = dlg.table.cellWidget(0, 1)
+    assert isinstance(spin, QtWidgets.QDoubleSpinBox)
+    assert spin.value() == pytest.approx(1.5)
+    spin.setValue(2.25)
+    assert dlg.params()["Value"] == "2.25"
+    evt = QtGui.QWheelEvent(
+        QtCore.QPointF(),
+        QtCore.QPointF(),
+        QtCore.QPoint(),
+        QtCore.QPoint(0, 120),
+        QtCore.Qt.MouseButton.NoButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+        QtCore.Qt.ScrollPhase.ScrollUpdate,
+        False,
+    )
+    QtWidgets.QApplication.sendEvent(spin, evt)
+    assert float(dlg.params()["Value"]) == pytest.approx(2.35, abs=0.001)

--- a/tests/test_main_window_buffer.py
+++ b/tests/test_main_window_buffer.py
@@ -56,8 +56,10 @@ def test_main_window_buffer_mode_populates_tables(qtbot, tmp_path: Path) -> None
     win._on_selected()
     assert win.sub_table.rowCount() == 2
     headers = [win.sub_table.horizontalHeaderItem(i).text() for i in range(win.sub_table.columnCount())]
-    assert "Macro" in headers and "Pins" in headers
+    for col in ["Macro", "PinA", "PinB", "PinC", "PinD", "PinS"]:
+        assert col in headers
 
     row0 = {headers[i]: (win.sub_table.item(0, i).text() if win.sub_table.item(0, i) else "") for i in range(win.sub_table.columnCount())}
     assert row0["Macro"] == "RELAIS"
-    assert "A=1" in row0["Pins"] and "D=4" in row0["Pins"]
+    assert row0["PinA"] == "1" and row0["PinD"] == "4"
+    assert row0["PinS"] == ""

--- a/tests/test_main_window_buffer_mode_populates_tables.py
+++ b/tests/test_main_window_buffer_mode_populates_tables.py
@@ -40,5 +40,7 @@ def test_main_window_buffer_mode_populates_tables(qtbot, tmp_path: Path) -> None
         win.sub_table.horizontalHeaderItem(i).text(): (win.sub_table.item(0, i).text() if win.sub_table.item(0, i) else "")
         for i in range(win.sub_table.columnCount())
     }
-    assert "S" not in row0["Pins"]
-    assert "A=1" in row0["Pins"] and "D=4" in row0["Pins"]
+    for col in ["PinA", "PinB", "PinC", "PinD", "PinS"]:
+        assert col in row0
+    assert row0["PinA"] == "1" and row0["PinD"] == "4"
+    assert row0["PinS"] == "<xml>ignored</xml>"


### PR DESCRIPTION
## Summary
- serialize macros with defaults omitted and validate GATE checks
- show PinA–D columns and raw PinS XML in the main window
- preserve raw PinS data when loading buffer complexes
- allow editing macro parameter values with mouse-wheel float spinboxes

## Testing
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=src pytest -q` *(fails: 28 failed, 142 passed, 1 skipped)*
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=src pytest tests/test_macro_params_dialog_spinbox.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a05af47ce8832ca426d193088d004c