### PR TITLE
Handle macro parameter aliases during XML conversion

### DIFF
--- a/src/mdb_comm/data/macro_param_aliases.yaml
+++ b/src/mdb_comm/data/macro_param_aliases.yaml
@@ -1,0 +1,2 @@
+VOLTAGEREGULATOR:
+  InVolt: Value

--- a/src/mdb_comm/macro_xml_translator.py
+++ b/src/mdb_comm/macro_xml_translator.py
@@ -16,12 +16,16 @@ LOGGER = logging.getLogger(__name__)
 DATA_DIR = Path(__file__).resolve().parent / "data"
 RES_DIR = Path(__file__).resolve().parents[1] / "complex_editor" / "resources"
 DEFAULTS_PATH = RES_DIR / "function_param_allowed.yaml"
+PARAM_ALIASES_PATH = DATA_DIR / "macro_param_aliases.yaml"
 
 
 def _load_yaml(path: str | Path) -> Mapping[str, Any]:
     p = Path(path)
-    with p.open("r", encoding="utf-8") as f:
-        return yaml.safe_load(f) or {}
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        return {}
 
 
 @lru_cache(maxsize=1)
@@ -37,6 +41,11 @@ def _load_defaults(path: str | Path = DEFAULTS_PATH) -> Mapping[str, Mapping[str
                     d[pname] = spec["default"]
             result[fname] = d
     return result
+
+
+@lru_cache(maxsize=1)
+def _load_param_aliases(path: str | Path = PARAM_ALIASES_PATH) -> Mapping[str, Mapping[str, str]]:
+    return _load_yaml(path)
 
 
 def _is_default(val: Any, default: Any) -> bool:
@@ -79,6 +88,7 @@ def params_to_xml(
         rules = load_rules(DATA_DIR / "macro_selection_rules.yaml")
     if fn_map is None:
         fn_map = _load_yaml(DATA_DIR / "function_to_xml_macro_map.yaml")
+    param_aliases = _load_param_aliases()
 
     defaults = _load_defaults()
     macros = {}
@@ -94,11 +104,14 @@ def params_to_xml(
             reason = "fallback"
         LOGGER.info("macro-choice", extra={"function": fname, "macro": macro, "reason": reason})
         dvals = defaults.get(fname, {})
-        filtered = {
-            pname: val
-            for pname, val in pvals.items()
-            if not (pname in dvals and _is_default(val, dvals[pname]))
-        }
+        aliases = param_aliases.get(fname, {})
+        inverse_aliases = {v: k for k, v in aliases.items()}
+        filtered = {}
+        for pname, val in pvals.items():
+            if pname in dvals and _is_default(val, dvals[pname]):
+                continue
+            macro_pname = inverse_aliases.get(pname, pname)
+            filtered[macro_pname] = val
         macros[macro] = filtered
     return _params_to_xml(macros)
 
@@ -112,6 +125,7 @@ def xml_to_params(
 
     if inv_map is None:
         inv_map = _load_yaml(DATA_DIR / "xml_macro_to_function_map.yaml")
+    param_aliases = _load_param_aliases()
     macros = _xml_to_params(xml)
     result = {}
     for mname, params in macros.items():
@@ -123,7 +137,9 @@ def xml_to_params(
                 LOGGER.warning("ambiguous-macro-name", extra={"macro": mname, "function": fname})
             else:
                 fname = mname
-        result[fname] = params
+        aliases = param_aliases.get(fname, {})
+        renamed = {aliases.get(p, p): v for p, v in params.items()}
+        result[fname] = renamed
     return result
 
 

--- a/tests/test_macro_param_aliases.py
+++ b/tests/test_macro_param_aliases.py
@@ -1,0 +1,18 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from mdb_comm.macro_xml_translator import xml_to_params, params_to_xml
+
+
+def test_param_alias_roundtrip():
+    xml = (
+        '<?xml version="1.0" encoding="utf-16"?>'
+        '<R><Macros><Macro Name="VOLTAGE_REG">'
+        '<Param Name="InVolt" Value="5" />'
+        '</Macro></Macros></R>'
+    ).encode("utf-16")
+    params = xml_to_params(xml)
+    assert params["VOLTAGEREGULATOR"]["Value"] == "5"
+    new_xml = params_to_xml({"VOLTAGEREGULATOR": {"Value": 5}})
+    txt = new_xml.decode("utf-16")
+    assert 'Name="InVolt" Value="5"' in txt

--- a/tools/xml-func converter/macro_param_aliases.yaml
+++ b/tools/xml-func converter/macro_param_aliases.yaml
@@ -1,0 +1,2 @@
+VOLTAGEREGULATOR:
+  InVolt: Value


### PR DESCRIPTION
## Summary
- support mapping between macro parameter names and canonical function parameters
- add `macro_param_aliases.yaml` with example alias for `VOLTAGEREGULATOR`
- test round-trip conversions through new alias system

## Testing
- `pytest tests/test_macro_param_aliases.py tests/test_macro_params_roundtrip.py`
- `pytest` *(fails: 25 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68a5e9a419f0832c9787fafc7ed7ae1b