### PR TITLE
Refine Complex Editor dialog and main window persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Unreleased
+
+- Rename main application window to "Complex View".
+- Add new "Complex Editor" dialog for creating and editing complexes.
+- Share pin validation helpers across UIs and support parameter editing.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sqlalchemy>=2.0
 PyQt6>=6.6
 PyMuPDF>=1.24
 pyyaml>=6.0
+pytest-qt>=4.2

--- a/src/complex_editor/db/mdb_api.py
+++ b/src/complex_editor/db/mdb_api.py
@@ -203,11 +203,13 @@ class MDB:
         cx.name = new_name
         return self.create_complex(cx)
 
-    def add_complex(self, complex_dev: ComplexDevice) -> int:
-        """Public helper using the legacy service to insert a complex."""
-        from ..services.export_service import insert_complex
+    def add_complex(self, cx: ComplexDevice) -> int:
+        """Insert *cx* and return its new ID.
 
-        return insert_complex(self._conn, complex_dev)
+        This is an alias for :meth:`create_complex` maintained for backwards
+        compatibility with the old API.
+        """
+        return self.create_complex(cx)
 
     # ── modifiers --------------------------------------------------
     def update_complex(self, comp_id: int, updated: ComplexDevice | None = None, **fields):

--- a/src/complex_editor/domain/models.py
+++ b/src/complex_editor/domain/models.py
@@ -36,6 +36,11 @@ class ComplexDevice:
     id_function: int
     pins: List[str]
     macro: MacroInstance
+    pn: str = ""
+    alt_pn: str = ""
+    pin_count: int = 0
+    subcomponents: List[SubComponent] = field(default_factory=list)
+    id: int | None = None
 
 
 @dataclass

--- a/src/complex_editor/services/export_service.py
+++ b/src/complex_editor/services/export_service.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+"""Legacy helpers for the deprecated workflow.
+
+The new :mod:`complex_editor.ui.complex_editor` persists complexes via the
+``MDB`` API directly.  This module is kept for backwards compatibility with
+older tools and tests but is otherwise unused by the new flow.
+"""
+
 from ..db import table_exists
 from ..domain import ComplexDevice
 from ..util.macro_xml_translator import params_to_xml
@@ -35,3 +42,12 @@ def insert_complex(conn, complex_dev: ComplexDevice) -> int:
     params = (next_id, complex_dev.id_function, *pins, pin_s)
     cursor.execute(query, params)
     return next_id
+
+
+def update_complex(conn, complex_dev: ComplexDevice) -> int:
+    """Placeholder update operation for an existing complex."""
+
+    # The real implementation would mirror :func:`insert_complex` but issue an
+    # ``UPDATE`` statement instead.  The simplified editor and unit tests only
+    # need this function to exist so that it can be patched/mocked.
+    return complex_dev.id or 0

--- a/src/complex_editor/ui/complex_list.py
+++ b/src/complex_editor/ui/complex_list.py
@@ -55,6 +55,7 @@ class ComplexListModel(QtCore.QAbstractTableModel):
 class ComplexListPanel(QtWidgets.QWidget):
     complexSelected = QtCore.pyqtSignal(object)
     newComplexRequested = QtCore.pyqtSignal()
+    editRequested = QtCore.pyqtSignal(object)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -72,6 +73,7 @@ class ComplexListPanel(QtWidgets.QWidget):
             QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers
         )
         self.view.clicked.connect(self._on_clicked)
+        self.view.doubleClicked.connect(self._on_edit)
         layout.addWidget(self.view)
 
     def load_rows(self, cursor, macro_map):
@@ -83,3 +85,9 @@ class ComplexListPanel(QtWidgets.QWidget):
             return
         row = self.model.rows[index.row()]
         self.complexSelected.emit(row)
+
+    def _on_edit(self, index: QtCore.QModelIndex) -> None:
+        if not index.isValid():
+            return
+        row = self.model.rows[index.row()]
+        self.editRequested.emit(row)

--- a/src/complex_editor/ui/param_editor_dialog.py
+++ b/src/complex_editor/ui/param_editor_dialog.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Dialog used to edit macro parameters."""
+
+from typing import Dict
+from PyQt6 import QtWidgets
+
+from ..domain import MacroDef, MacroParam
+
+
+class ParamEditorDialog(QtWidgets.QDialog):
+    """Create a dialog populated from a :class:`MacroDef`.
+
+    Each parameter is represented by an appropriate Qt widget.  Upon
+    acceptance the :meth:`params` method returns a mapping of
+    ``{param_name: value}`` pairs using string values.
+    """
+
+    def __init__(self, macro: MacroDef, values: Dict[str, str] | None = None, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle(f"Parameters - {macro.name}")
+        self._macro = macro
+        layout = QtWidgets.QFormLayout(self)
+        self._widgets: dict[str, QtWidgets.QWidget] = {}
+        for p in macro.params:
+            w: QtWidgets.QWidget
+            if p.type == "INT":
+                w = QtWidgets.QSpinBox()
+                w.setMinimum(int(p.min or 0))
+                w.setMaximum(int(p.max or 1_000_000))
+            elif p.type == "FLOAT":
+                w = QtWidgets.QDoubleSpinBox()
+                w.setMinimum(float(p.min or 0.0))
+                w.setMaximum(float(p.max or 1e9))
+            elif p.type == "BOOL":
+                w = QtWidgets.QCheckBox()
+            elif p.type == "ENUM":
+                w = QtWidgets.QComboBox()
+                for choice in (p.default or "").split(";"):
+                    if choice:
+                        w.addItem(choice)
+            else:
+                w = QtWidgets.QLineEdit()
+            layout.addRow(p.name, w)
+            self._widgets[p.name] = w
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addRow(buttons)
+        if values:
+            self.set_values(values)
+
+    # ------------------------------------------------------------------
+    def set_values(self, values: Dict[str, str]) -> None:
+        for name, val in values.items():
+            w = self._widgets.get(name)
+            if w is None:
+                continue
+            if isinstance(w, QtWidgets.QSpinBox):
+                w.setValue(int(val))
+            elif isinstance(w, QtWidgets.QDoubleSpinBox):
+                w.setValue(float(val))
+            elif isinstance(w, QtWidgets.QCheckBox):
+                w.setChecked(str(val).lower() in {"1", "true", "yes"})
+            elif isinstance(w, QtWidgets.QComboBox):
+                idx = w.findText(str(val))
+                if idx >= 0:
+                    w.setCurrentIndex(idx)
+            else:
+                w.setText(str(val))
+
+    def params(self) -> Dict[str, str]:
+        result: Dict[str, str] = {}
+        for name, w in self._widgets.items():
+            if isinstance(w, QtWidgets.QSpinBox):
+                result[name] = str(w.value())
+            elif isinstance(w, QtWidgets.QDoubleSpinBox):
+                result[name] = str(w.value())
+            elif isinstance(w, QtWidgets.QCheckBox):
+                result[name] = "1" if w.isChecked() else "0"
+            elif isinstance(w, QtWidgets.QComboBox):
+                result[name] = w.currentText()
+            else:
+                result[name] = w.text()
+        return result

--- a/src/complex_editor/ui/validators.py
+++ b/src/complex_editor/ui/validators.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Validation helpers shared between GUI components."""
+
+from typing import Iterable, Sequence, Tuple
+
+
+def validate_pins(pins: Iterable[int], max_pin: int) -> Tuple[bool, str]:
+    """Validate *pins* against range and duplicate rules.
+
+    Parameters
+    ----------
+    pins:
+        Iterable of pin numbers; ``None`` values are ignored.
+    max_pin:
+        Highest allowed pin number.
+    Returns
+    -------
+    tuple
+        ``(is_valid, message)`` where ``message`` describes the first error.
+    """
+
+    numbers = [p for p in pins if p is not None]
+    for p in numbers:
+        if p < 1 or p > max_pin:
+            return False, f"pin {p} out of range"
+    if len(numbers) != len(set(numbers)):
+        return False, "duplicate pins"
+    return True, ""
+
+
+def validate_pin_table(rows: Sequence[Sequence[int]], max_pin: int) -> Tuple[bool, str]:
+    """Validate a full table of pin assignments.
+
+    The legacy ``NewComplexWizard`` rejected any reuse of a physical pad across
+    sub-components.  This helper mirrors those rules so both the wizard and the
+    new :class:`~complex_editor.ui.complex_editor.ComplexEditor` behave
+    identically.
+
+    Parameters
+    ----------
+    rows:
+        Iterable over pin rows ``[A, B, C, D]``.
+    max_pin:
+        Upper bound for allowed pin numbers.
+
+    Returns
+    -------
+    tuple
+        ``(is_valid, message)`` describing the first encountered violation.
+    """
+
+    used = set()
+    for r in rows:
+        ok, msg = validate_pins(r, max_pin)
+        if not ok:
+            return False, msg
+        for p in [x for x in r if x is not None and x > 0]:
+            if p in used:
+                return False, f"pin {p} reused"
+            used.add(p)
+    return True, ""

--- a/tests/domain/test_params_roundtrip.py
+++ b/tests/domain/test_params_roundtrip.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")))
+
+from complex_editor.util.macro_xml_translator import params_to_xml, xml_to_params
+
+
+def test_params_roundtrip():
+    data = {"GATE": {"StartFreq": "200", "StopFreq": "50000"}}
+    xml = params_to_xml(data, encoding="utf-16")
+    back = xml_to_params(xml)
+    assert back == {"GATE": {"StartFreq": "200", "StopFreq": "50000"}}

--- a/tests/test_main_window_title.py
+++ b/tests/test_main_window_title.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from pathlib import Path
+
+import types
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from PyQt6 import QtWidgets  # noqa: E402
+from complex_editor.ui.main_window import MainWindow  # noqa: E402
+
+
+
+class DummyDB:
+    def list_complexes(self):
+        return []
+
+
+class DummyCtx:
+    def open_main_db(self, _):
+        return DummyDB()
+
+
+def test_window_title(qtbot, monkeypatch):
+    monkeypatch.setattr("complex_editor.ui.main_window.AppContext", lambda: DummyCtx())
+    win = MainWindow(Path("dummy.mdb"))
+    qtbot.addWidget(win)
+    assert win.windowTitle() == "Complex View"

--- a/tests/ui/test_buffer_edit_flow.py
+++ b/tests/ui/test_buffer_edit_flow.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")))
+
+from PyQt6 import QtWidgets, QtCore
+from complex_editor.ui.main_window import MainWindow, AppContext
+from complex_editor.ui.complex_editor import ComplexEditor
+import complex_editor.db.schema_introspect as schema_introspect
+
+
+def test_buffer_edit_updates_json(tmp_path, qtbot, monkeypatch):
+    data = [
+        {
+            "id": 1,
+            "name": "CX",
+            "pins": ["1", "2", "3", "4"],
+            "subcomponents": [
+                {
+                    "function_name": "GATE",
+                    "pins": {
+                        "A": 1,
+                        "B": 2,
+                        "C": 3,
+                        "D": 4,
+                        "S": "<GATE><P>1</P></GATE>",
+                    },
+                }
+            ],
+        }
+    ]
+    buf_path = tmp_path / "buf.json"
+    buf_path.write_text(json.dumps(data))
+
+    monkeypatch.setattr(AppContext, "open_main_db", lambda *a, **k: None)
+    monkeypatch.setattr(schema_introspect, "discover_macro_map", lambda _c: {})
+
+    win = MainWindow(buffer_path=buf_path)
+    qtbot.addWidget(win)
+
+    win.list.setCurrentCell(0, 0)
+
+    def fake_exec(self):
+        self.alt_pn_edit.setText("ALT2")
+        self._update_state()
+        assert self.save_btn.isEnabled()
+        self._on_accept()
+        return QtWidgets.QDialog.DialogCode.Accepted
+
+    monkeypatch.setattr(ComplexEditor, "exec", fake_exec)
+    win._on_edit()
+
+    raw = json.loads(buf_path.read_text())
+    xml = raw[0]["subcomponents"][0]["pins"]["S"]
+    assert "<Macro Name=\"GATE\"" in xml
+    assert raw[0]["alt_pn"] == "ALT2"

--- a/tests/ui/test_complex_editor_edit_flow.py
+++ b/tests/ui/test_complex_editor_edit_flow.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")))
+
+from PyQt6 import QtCore
+from PyQt6 import QtWidgets
+from complex_editor.ui.complex_editor import ComplexEditor
+from complex_editor.domain import ComplexDevice, MacroDef, MacroInstance, MacroParam, SubComponent
+
+
+def _macro_map():
+    macro = MacroDef(1, "GATE", [MacroParam("P", "INT", None, "0", "10")])
+    return {1: macro}
+
+
+def test_complex_editor_edit_flow(qtbot, monkeypatch):
+    sc = SubComponent(MacroInstance("GATE", {"P": "1"}), [1, 2, 3, 4])
+    dev = ComplexDevice(0, [], MacroInstance("", {}), pn="CX1", pin_count=4, subcomponents=[sc], id=5)
+    editor = ComplexEditor(_macro_map())
+    qtbot.addWidget(editor)
+    editor.load_device(dev)
+    editor.alt_pn_edit.setText("ALT")
+    editor._update_state()
+    assert editor.save_btn.isEnabled()
+    editor._on_accept()
+    dev2 = editor.build_device()
+    assert dev2.id == 5
+    assert dev2.alt_pn == "ALT"

--- a/tests/ui/test_complex_editor_new_flow.py
+++ b/tests/ui/test_complex_editor_new_flow.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")))
+
+from PyQt6 import QtCore
+from PyQt6 import QtWidgets
+from complex_editor.ui.complex_editor import ComplexEditor
+from complex_editor.domain import MacroDef, MacroParam
+
+
+def _macro_map():
+    macro = MacroDef(1, "GATE", [MacroParam("P", "INT", None, "0", "10")])
+    return {1: macro}
+
+
+def test_complex_editor_new_flow(qtbot, monkeypatch):
+    editor = ComplexEditor(_macro_map())
+    qtbot.addWidget(editor)
+    editor.pn_edit.setText("CX1")
+    editor.pin_spin.setValue(4)
+    row = editor.model.add_row()
+    editor.model.setData(editor.model.index(row, 1), 1, QtCore.Qt.ItemDataRole.EditRole)
+    editor.model.setData(editor.model.index(row, 2), 1, QtCore.Qt.ItemDataRole.EditRole)
+    editor.model.setData(editor.model.index(row, 3), 2, QtCore.Qt.ItemDataRole.EditRole)
+    editor.model.setData(editor.model.index(row, 4), 3, QtCore.Qt.ItemDataRole.EditRole)
+    editor.model.setData(editor.model.index(row, 5), 4, QtCore.Qt.ItemDataRole.EditRole)
+    editor.model.rows[row].params = {"P": "1"}
+    editor._update_state()
+    assert editor.save_btn.isEnabled()
+    editor._on_accept()
+    dev = editor.build_device()
+    assert dev.pn == "CX1"
+    assert dev.subcomponents and dev.subcomponents[0].pins[:2] == [1, 2]

--- a/tests/ui/test_macro_combo_delegate.py
+++ b/tests/ui/test_macro_combo_delegate.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")))
+
+from PyQt6 import QtCore
+from complex_editor.ui.complex_editor import ComplexEditor
+from complex_editor.domain import MacroDef, MacroParam
+
+
+def _macro_map():
+    return {1: MacroDef(1, "M1", []), 2: MacroDef(2, "M2", [MacroParam("P", "INT", None, "0", "10")])}
+
+
+def test_macro_combo_delegate_updates_model(qtbot):
+    editor = ComplexEditor(_macro_map())
+    qtbot.addWidget(editor)
+    row = editor.model.add_row()
+    idx = editor.model.index(row, 1)
+    delegate = editor.table.itemDelegateForColumn(1)
+    combo = delegate.createEditor(editor.table, None, idx)
+    delegate.setEditorData(combo, idx)
+    combo.setCurrentIndex(combo.findData(2))
+    delegate.setModelData(combo, editor.model, idx)
+    assert editor.model.rows[row].macro_id == 2
+    assert editor.model.data(idx, QtCore.Qt.ItemDataRole.DisplayRole) == "M2"

--- a/tests/ui/test_main_window_db_create.py
+++ b/tests/ui/test_main_window_db_create.py
@@ -1,0 +1,74 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")))
+
+from PyQt6 import QtWidgets
+from complex_editor.ui.main_window import MainWindow
+from complex_editor.ui.main_window import AppContext
+from complex_editor.domain import MacroDef, MacroParam, MacroInstance, ComplexDevice, SubComponent
+from complex_editor.db.mdb_api import ComplexDevice as DbComplex
+from complex_editor.util.macro_xml_translator import xml_to_params
+import complex_editor.db.schema_introspect as schema_introspect
+
+
+class DummyConn:
+    def cursor(self):
+        return object()
+
+    def commit(self):
+        pass
+
+
+class DummyDB:
+    def __init__(self):
+        self.add_complex_called = None
+        self._conn = DummyConn()
+
+    def list_functions(self):
+        return [(1, "GATE")]
+
+    def list_complexes(self):
+        return []
+
+    def add_complex(self, cx):
+        self.add_complex_called = cx
+
+
+class FakeEditor(QtWidgets.QDialog):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def exec(self):
+        return QtWidgets.QDialog.DialogCode.Accepted
+
+    def build_device(self):
+        sc = SubComponent(MacroInstance("GATE", {"P": "1"}), [1, 2, 0, 0])
+        dev = ComplexDevice(0, [], MacroInstance("", {}))
+        dev.pn = "CX1"
+        dev.pin_count = 4
+        dev.subcomponents = [sc]
+        return dev
+
+
+def test_db_create_called(qtbot, monkeypatch):
+    dummy = DummyDB()
+    monkeypatch.setattr(AppContext, "open_main_db", lambda self, path: dummy)
+    monkeypatch.setattr(schema_introspect, "discover_macro_map", lambda _c: {1: MacroDef(1, "GATE", [MacroParam("P", "INT", None, "0", "10")])})
+    monkeypatch.setattr("complex_editor.ui.main_window.ComplexEditor", FakeEditor)
+
+    win = MainWindow(mdb_path=Path("dummy.mdb"))
+    qtbot.addWidget(win)
+
+    win._new_complex()
+
+    called = dummy.add_complex_called
+    assert isinstance(called, DbComplex)
+    assert called.subcomponents
+    sc = called.subcomponents[0]
+    assert sc.id_function == 1
+    assert sc.pins["A"] == 1 and sc.pins["B"] == 2
+    params = xml_to_params(sc.pins["S"])
+    assert params["GATE"]["P"] == "1"

--- a/tests/ui/test_pin_validation.py
+++ b/tests/ui/test_pin_validation.py
@@ -1,0 +1,69 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")))
+
+from PyQt6 import QtCore
+from complex_editor.ui.validators import validate_pins
+from complex_editor.ui.complex_editor import ComplexEditor
+from complex_editor.domain import MacroDef, MacroParam
+
+
+def test_pin_validation():
+    assert validate_pins([1, 2, 3, 4], 4)[0]
+    assert not validate_pins([1, 2, 2], 4)[0]
+    assert not validate_pins([0, 1], 4)[0]
+
+
+def _macro_map():
+    return {1: MacroDef(1, "M", [MacroParam("P", "INT", None, "0", "5")])}
+
+
+def test_pin_delegate_rejects_invalid(qtbot):
+    editor = ComplexEditor(_macro_map())
+    qtbot.addWidget(editor)
+    editor.pn_edit.setText("CX")
+    editor.pin_spin.setValue(4)
+    row = editor.model.add_row()
+    editor.model.setData(editor.model.index(row, 1), 1, QtCore.Qt.ItemDataRole.EditRole)
+    delegate = editor.table.itemDelegateForColumn(2)
+    idx = editor.model.index(row, 2)
+    spin = delegate.createEditor(editor.table, None, idx)
+    delegate.setEditorData(spin, idx)
+    spin.setValue(1)
+    delegate.setModelData(spin, editor.model, idx)
+    idx_b = editor.model.index(row, 3)
+    spin_b = delegate.createEditor(editor.table, None, idx_b)
+    delegate.setEditorData(spin_b, idx_b)
+    spin_b.setValue(1)  # duplicate
+    delegate.setModelData(spin_b, editor.model, idx_b)
+    editor._update_state()
+    assert not editor.save_btn.isEnabled()
+    spin_b.setValue(5)  # out of range -> clamped to 4
+    delegate.setModelData(spin_b, editor.model, idx_b)
+    assert editor.model.rows[row].pins[1] <= 4
+
+
+def test_cross_row_duplicate_pins_disable_save(qtbot):
+    editor = ComplexEditor(_macro_map())
+    qtbot.addWidget(editor)
+    editor.pn_edit.setText("CX")
+    editor.pin_spin.setValue(4)
+    r1 = editor.model.add_row()
+    r2 = editor.model.add_row()
+    editor.model.setData(editor.model.index(r1, 1), 1, QtCore.Qt.ItemDataRole.EditRole)
+    editor.model.setData(editor.model.index(r2, 1), 1, QtCore.Qt.ItemDataRole.EditRole)
+    delegate = editor.table.itemDelegateForColumn(2)
+    idx1 = editor.model.index(r1, 2)
+    sp1 = delegate.createEditor(editor.table, None, idx1)
+    delegate.setEditorData(sp1, idx1)
+    sp1.setValue(1)
+    delegate.setModelData(sp1, editor.model, idx1)
+    idx2 = editor.model.index(r2, 2)
+    sp2 = delegate.createEditor(editor.table, None, idx2)
+    delegate.setEditorData(sp2, idx2)
+    sp2.setValue(1)
+    delegate.setModelData(sp2, editor.model, idx2)
+    editor._update_state()
+    assert not editor.save_btn.isEnabled()


### PR DESCRIPTION
## Summary
- Enforce legacy pin rules with shared validators and ensure cross-row duplicates keep Save disabled
- Route new and edit actions through ComplexEditor in DB and buffer modes, persisting via `add_complex` and updating buffer JSON
- Note legacy status of export service and document alt-PN’s UI-only nature
- Synthesize macro definitions from buffer content when database lookup fails and test buffer editing with the real ComplexEditor

## Testing
- `apt-get update >/tmp/apt.log && apt-get install -y libgl1 libegl1 libxkbcommon0 >/tmp/apt.log && tail -n 20 /tmp/apt.log`
- `pip install -q -r requirements.txt`
- `pytest tests/ui/test_complex_editor_new_flow.py tests/ui/test_complex_editor_edit_flow.py tests/ui/test_macro_combo_delegate.py tests/ui/test_pin_validation.py tests/ui/test_main_window_db_create.py tests/ui/test_buffer_edit_flow.py tests/test_main_window_title.py tests/domain/test_params_roundtrip.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6f1ab8564832c8b6300c19c45cac0