### PR TITLE
Clamp QSpinBox range for oversized macro parameters

### DIFF
--- a/src/complex_editor/ui/param_editor_dialog.py
+++ b/src/complex_editor/ui/param_editor_dialog.py
@@ -26,8 +26,20 @@ class ParamEditorDialog(QtWidgets.QDialog):
             w: QtWidgets.QWidget
             if p.type == "INT":
                 w = QtWidgets.QSpinBox()
-                w.setMinimum(int(p.min or 0))
-                w.setMaximum(int(p.max or 1_000_000))
+                # QSpinBox only supports 32-bit signed integers.  Some macros
+                # specify values outside this range which would otherwise raise
+                # an ``OverflowError`` when passed to ``setMinimum``/``setMaximum``.
+                # Clamp to the valid range to keep the dialog usable even with
+                # overly large macro definitions.
+                min_val = int(p.min or 0)
+                max_val = int(p.max or 1_000_000)
+                INT_MIN, INT_MAX = -2**31, 2**31 - 1
+                min_val = max(min_val, INT_MIN)
+                max_val = min(max_val, INT_MAX)
+                if min_val > max_val:
+                    min_val = max_val
+                w.setMinimum(min_val)
+                w.setMaximum(max_val)
             elif p.type == "FLOAT":
                 w = QtWidgets.QDoubleSpinBox()
                 w.setMinimum(float(p.min or 0.0))

--- a/tests/test_param_editor_dialog_clamps_spinbox.py
+++ b/tests/test_param_editor_dialog_clamps_spinbox.py
@@ -1,0 +1,16 @@
+from complex_editor.domain import MacroDef, MacroParam
+from complex_editor.ui.param_editor_dialog import ParamEditorDialog
+from PyQt6 import QtWidgets
+
+
+def test_param_editor_dialog_clamps_spinbox(qtbot):
+    """Spin boxes should clamp values to the valid range to avoid overflow."""
+    big_min = str(-2**40)
+    big_max = str(2**40)
+    macro = MacroDef(0, "M", [MacroParam("p", "INT", None, big_min, big_max)])
+    dlg = ParamEditorDialog(macro)
+    qtbot.addWidget(dlg)
+    spin = dlg._widgets["p"]
+    assert isinstance(spin, QtWidgets.QSpinBox)
+    assert spin.minimum() == -2**31
+    assert spin.maximum() == 2**31 - 1


### PR DESCRIPTION
## Summary
- prevent overflow in ParamEditorDialog by clamping INT parameter limits to 32‑bit signed range
- add regression test for clamping oversized min/max values

## Testing
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=src pytest tests/test_param_editor_dialog_clamps_spinbox.py -q`
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=src pytest -q` *(fails: assert 'PinS' in '', AttributeError: 'module' object at complex_editor.ui.main_window has no attribute 'NewComplexWizard', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a71579e0d8832cb729fdf4a563b903