### PR TITLE
Clamp QSpinBox range for oversized macro parameters

### DIFF
--- a/tests/test_param_editor_dialog_clamps_spinbox.py
+++ b/tests/test_param_editor_dialog_clamps_spinbox.py
@@ -1,0 +1,16 @@
+from complex_editor.domain import MacroDef, MacroParam
+from complex_editor.ui.param_editor_dialog import ParamEditorDialog
+from PyQt6 import QtWidgets
+
+
+def test_param_editor_dialog_clamps_spinbox(qtbot):
+    """Spin boxes should clamp values to the valid range to avoid overflow."""
+    big_min = str(-2**40)
+    big_max = str(2**40)
+    macro = MacroDef(0, "M", [MacroParam("p", "INT", None, big_min, big_max)])
+    dlg = ParamEditorDialog(macro)
+    qtbot.addWidget(dlg)
+    spin = dlg._widgets["p"]
+    assert isinstance(spin, QtWidgets.QSpinBox)
+    assert spin.minimum() == -2**31
+    assert spin.maximum() == 2**31 - 1

--- a/tests/test_param_editor_dialog_int_accepts_float.py
+++ b/tests/test_param_editor_dialog_int_accepts_float.py
@@ -1,0 +1,14 @@
+from complex_editor.domain import MacroDef, MacroParam
+from complex_editor.ui.param_editor_dialog import ParamEditorDialog
+from PyQt6 import QtWidgets
+
+
+def test_param_editor_dialog_int_accepts_float(qtbot):
+    """Float values for INT parameters should not crash the dialog."""
+    macro = MacroDef(0, "M", [MacroParam("p", "INT", None, None, None)])
+    dlg = ParamEditorDialog(macro, {"p": "4.9"})
+    qtbot.addWidget(dlg)
+    spin = dlg._widgets["p"]
+    assert isinstance(spin, QtWidgets.QSpinBox)
+    assert spin.value() == 4
+    assert dlg.params()["p"] == "4"


### PR DESCRIPTION
## Summary
- prevent overflow in ParamEditorDialog by clamping INT parameter limits to 32‑bit signed range
- coerce float string defaults for INT parameters to avoid crashes when editing macros
- add regression tests for clamping and float coercion

## Testing
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=src pytest tests/test_param_editor_dialog_clamps_spinbox.py tests/test_param_editor_dialog_int_accepts_float.py -q`
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=src pytest -q` *(fails: assert 'PinS' in '', AttributeError: 'module' object at complex_editor.ui.main_window has no attribute 'NewComplexWizard', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a71579e0d8832cb729fdf4a563b903