### PR TITLE
Clamp QSpinBox range and parse PinS/S in buffer loader

### DIFF
--- a/tests/test_buffer_loader_handles_pinS.py
+++ b/tests/test_buffer_loader_handles_pinS.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+
+from complex_editor.ui.buffer_loader import load_editor_complexes_from_buffer
+
+
+def _make_xml():
+    return (
+        '<?xml version="1.0"?><R><Macros><Macro Name="FAN">'
+        '<Param Name="Speed" Value="3"/></Macro></Macros></R>'
+    )
+
+
+def test_loads_params_from_PinS_key(tmp_path: Path):
+    xml = _make_xml()
+    buf = [
+        {
+            "id": 1,
+            "name": "DEV",
+            "pins": ["1"],
+            "subcomponents": [
+                {
+                    "function_name": "FAN",
+                    "pins": {"A": "1", "PinS": xml},
+                }
+            ],
+        }
+    ]
+    path = tmp_path / "buf.json"
+    path.write_text(json.dumps(buf), encoding="utf-8")
+
+    complexes = load_editor_complexes_from_buffer(path)
+    sc = complexes[0].subcomponents[0]
+    assert sc.macro_params.get("Speed") == "3"
+
+
+def test_loads_params_from_top_level_S(tmp_path: Path):
+    xml = _make_xml()
+    buf = [
+        {
+            "id": 1,
+            "name": "DEV",
+            "pins": ["1"],
+            "subcomponents": [
+                {
+                    "function_name": "FAN",
+                    "S": xml,
+                    "pins": {"A": "1"},
+                }
+            ],
+        }
+    ]
+    path = tmp_path / "buf.json"
+    path.write_text(json.dumps(buf), encoding="utf-8")
+
+    complexes = load_editor_complexes_from_buffer(path)
+    sc = complexes[0].subcomponents[0]
+    assert sc.macro_params.get("Speed") == "3"
+
+
+def test_skips_74cx08m(tmp_path: Path):
+    xml = _make_xml()
+    buf = [
+        {
+            "id": 1,
+            "name": "DEV",
+            "pins": ["1"],
+            "subcomponents": [
+                {
+                    "function_name": "74CX08M",
+                    "pins": {"A": "1", "S": xml},
+                }
+            ],
+        }
+    ]
+    path = tmp_path / "buf.json"
+    path.write_text(json.dumps(buf), encoding="utf-8")
+
+    complexes = load_editor_complexes_from_buffer(path)
+    sc = complexes[0].subcomponents[0]
+    assert sc.macro_params == {}

--- a/tests/test_param_editor_dialog_clamps_spinbox.py
+++ b/tests/test_param_editor_dialog_clamps_spinbox.py
@@ -1,0 +1,16 @@
+from complex_editor.domain import MacroDef, MacroParam
+from complex_editor.ui.param_editor_dialog import ParamEditorDialog
+from PyQt6 import QtWidgets
+
+
+def test_param_editor_dialog_clamps_spinbox(qtbot):
+    """Spin boxes should clamp values to the valid range to avoid overflow."""
+    big_min = str(-2**40)
+    big_max = str(2**40)
+    macro = MacroDef(0, "M", [MacroParam("p", "INT", None, big_min, big_max)])
+    dlg = ParamEditorDialog(macro)
+    qtbot.addWidget(dlg)
+    spin = dlg._widgets["p"]
+    assert isinstance(spin, QtWidgets.QSpinBox)
+    assert spin.minimum() == -2**31
+    assert spin.maximum() == 2**31 - 1

--- a/tests/test_param_editor_dialog_int_accepts_float.py
+++ b/tests/test_param_editor_dialog_int_accepts_float.py
@@ -1,0 +1,14 @@
+from complex_editor.domain import MacroDef, MacroParam
+from complex_editor.ui.param_editor_dialog import ParamEditorDialog
+from PyQt6 import QtWidgets
+
+
+def test_param_editor_dialog_int_accepts_float(qtbot):
+    """Float values for INT parameters should not crash the dialog."""
+    macro = MacroDef(0, "M", [MacroParam("p", "INT", None, None, None)])
+    dlg = ParamEditorDialog(macro, {"p": "4.9"})
+    qtbot.addWidget(dlg)
+    spin = dlg._widgets["p"]
+    assert isinstance(spin, QtWidgets.QSpinBox)
+    assert spin.value() == 4
+    assert dlg.params()["p"] == "4"


### PR DESCRIPTION
## Summary
- prevent overflow in ParamEditorDialog by clamping INT parameter limits to 32‑bit signed range
- coerce float string defaults for INT parameters to avoid crashes when editing macros
- parse `PinS`/`S` aliases in buffer loader so macro parameters from legacy buffers populate the editor, skipping legacy component `74CX08M`
- add regression tests for PinS parsing, clamping, float coercion, and top-level `S`

## Testing
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=src pytest tests/test_buffer_loader_handles_pinS.py tests/test_param_editor_dialog_clamps_spinbox.py tests/test_param_editor_dialog_int_accepts_float.py -q`
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=src pytest -q` *(fails: AssertionError: 'PinS' in '', AttributeError: module object has no attribute 'NewComplexWizard', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a71579e0d8832cb729fdf4a563b903