### PR TITLE
Use floats for macro params and display editor in two columns

### DIFF
--- a/tests/test_macro_params_dialog_spinbox.py
+++ b/tests/test_macro_params_dialog_spinbox.py
@@ -4,13 +4,13 @@ from complex_editor.ui.param_editor import MacroParamsDialog
 
 
 def test_macro_params_dialog_spinbox_allows_float_and_wheel(qtbot):
-    dlg = MacroParamsDialog({"Value": "1.5"})
+    dlg = MacroParamsDialog({"Value": 1.5})
     qtbot.addWidget(dlg)
     spin = dlg.table.cellWidget(0, 1)
     assert isinstance(spin, QtWidgets.QDoubleSpinBox)
     assert spin.value() == pytest.approx(1.5)
     spin.setValue(2.25)
-    assert dlg.params()["Value"] == "2.25"
+    assert dlg.params()["Value"] == pytest.approx(2.25)
     evt = QtGui.QWheelEvent(
         QtCore.QPointF(),
         QtCore.QPointF(),
@@ -22,4 +22,4 @@ def test_macro_params_dialog_spinbox_allows_float_and_wheel(qtbot):
         False,
     )
     QtWidgets.QApplication.sendEvent(spin, evt)
-    assert float(dlg.params()["Value"]) == pytest.approx(2.35, abs=0.001)
+    assert dlg.params()["Value"] == pytest.approx(2.35, abs=0.001)

--- a/tests/test_param_editor_dialog_two_columns.py
+++ b/tests/test_param_editor_dialog_two_columns.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from PyQt6 import QtWidgets
+from complex_editor.ui.param_editor_dialog import ParamEditorDialog
+from complex_editor.domain import MacroDef, MacroParam
+
+
+def test_param_editor_dialog_arranges_two_columns(qtbot):
+    params = [MacroParam(f"P{i}", "INT", None, None, None) for i in range(5)]
+    macro = MacroDef(1, "MAC", params)
+    dlg = ParamEditorDialog(macro)
+    qtbot.addWidget(dlg)
+    layout = dlg.layout()
+    assert isinstance(layout, QtWidgets.QGridLayout)
+    assert isinstance(layout.itemAtPosition(0, 0).widget(), QtWidgets.QLabel)
+    assert layout.itemAtPosition(0, 0).widget().text() == "P0"
+    assert layout.itemAtPosition(1, 0).widget().text() == "P1"
+    assert layout.itemAtPosition(2, 0).widget().text() == "P2"
+    assert layout.itemAtPosition(0, 2).widget().text() == "P3"
+    assert layout.itemAtPosition(1, 2).widget().text() == "P4"
+


### PR DESCRIPTION
## Summary
- treat macro parameter values as floats in the generic macro params dialog
- arrange parameter editor widgets in two equal columns
- add regression test for two-column parameter layout

## Testing
- `python -m pytest`
- `PYTHONPATH=src python -m pytest tests/test_macro_params_dialog_spinbox.py tests/test_param_editor_dialog_clamps_spinbox.py tests/test_param_editor_dialog_int_accepts_float.py tests/test_param_editor_dialog_two_columns.py tests/ui/test_param_dialog_values_without_schema.py tests/ui/test_param_editor_accepts_extra_enum.py`


------
https://chatgpt.com/codex/tasks/task_e_68aabe83fc88832cac654f9affaab082