### PR TITLE
Improve PinS XML handling and editor interactions

### DIFF
--- a/tests/test_pinxml.py
+++ b/tests/test_pinxml.py
@@ -6,3 +6,11 @@ def test_roundtrip():
     xml = PinXML.serialize(given)
     got = PinXML.deserialize(xml)
     assert got == given
+
+
+def test_omit_default_params():
+    inst = MacroInstance("CAPACITOR", {"MeasureMode": "Default", "Frequency": 10})
+    xml = PinXML.serialize([inst])
+    txt = xml.decode("utf-16")
+    assert "MeasureMode" not in txt
+    assert "Frequency" in txt


### PR DESCRIPTION
## Summary
- skip default macro parameters when serializing PinS XML
- allow editing and reordering of sub-component rows
- highlight non-default macro parameter values in the editor

## Testing
- `ruff check src/complex_editor/domain/pinxml.py src/complex_editor/ui/complex_editor.py src/complex_editor/ui/param_editor_dialog.py tests/test_pinxml.py`
- `pytest` *(fails: assert 0 == -100, etc.)*
- `pytest tests/test_pinxml.py`


------
https://chatgpt.com/codex/tasks/task_e_68aae46b08d0832c969df96c540bfd02