### PR TITLE
Make subcomponent pins immutable

### DIFF
--- a/src/complex_editor/domain/models.py
+++ b/src/complex_editor/domain/models.py
@@ -46,8 +46,11 @@ class ComplexDevice:
 @dataclass
 class SubComponent:
     """One macro instance mapped to specific pins within a complex."""
-
     macro: MacroInstance
-    pins: list[int] = field(default_factory=list)
+    pins: tuple[int, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        # ensure an immutable tuple is always stored internally
+        self.pins = tuple(self.pins)
 
 

--- a/src/complex_editor/ui/complex_editor.py
+++ b/src/complex_editor/ui/complex_editor.py
@@ -170,7 +170,7 @@ class ComplexSubComponentsModel(QtCore.QAbstractTableModel):
             macro = self.macro_map.get(r.macro_id)
             name = macro.name if macro else str(r.macro_id)
             inst = MacroInstance(name, dict(r.params))
-            result.append(SubComponent(inst, list(r.pins)))
+            result.append(SubComponent(inst, tuple(r.pins)))
         return result
 
 

--- a/src/complex_editor/ui/main_window.py
+++ b/src/complex_editor/ui/main_window.py
@@ -340,7 +340,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
                 params = xml_map.get(mname) or (next(iter(xml_map.values())) if xml_map else {})
 
-                dev.subcomponents.append(SubComponent(MacroInstance(mname, params), pins))
+                dev.subcomponents.append(SubComponent(MacroInstance(mname, params), tuple(pins)))
             editor.load_device(dev)
             if editor.exec() == QtWidgets.QDialog.DialogCode.Accepted:
                 updated = editor.build_device()
@@ -412,7 +412,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
             params = xml_map.get(name) or (next(iter(xml_map.values())) if xml_map else {})
 
-            dev.subcomponents.append(SubComponent(MacroInstance(name, params), pin_list))
+            dev.subcomponents.append(SubComponent(MacroInstance(name, params), tuple(pin_list)))
         editor.load_device(dev)
         if editor.exec() == QtWidgets.QDialog.DialogCode.Accepted:
             updated = editor.build_device()

--- a/src/complex_editor/ui/new_complex_wizard.py
+++ b/src/complex_editor/ui/new_complex_wizard.py
@@ -943,7 +943,7 @@ class NewComplexWizard(QtWidgets.QDialog):
             if sc.get("id_function") is not None:
                 mi.id_function = sc.get("id_function")
             s_xml = sc.get("pins_s") or sc.get("S")
-            subc = SubComponent(mi, pins)
+            subc = SubComponent(mi, tuple(pins))
             val_field = sc.get("value")
             if val_field not in (None, ""):
                 setattr(subc, "value", val_field)
@@ -1032,7 +1032,7 @@ class NewComplexWizard(QtWidgets.QDialog):
             if sc.get("id_function") is not None:
                 mi.id_function = sc.get("id_function")
             s_xml = sc.get("pins_s") or sc.get("S")
-            subc = SubComponent(mi, pins)
+            subc = SubComponent(mi, tuple(pins))
             val_field = sc.get("value")
             if val_field not in (None, ""):
                 setattr(subc, "value", val_field)
@@ -1100,7 +1100,7 @@ class NewComplexWizard(QtWidgets.QDialog):
         return wiz
     # ------------------------------------------------------------------ actions
     def _add_sub(self) -> None:
-        sc = SubComponent(MacroInstance("", {}), [])
+        sc = SubComponent(MacroInstance("", {}), ())
         self.sub_components.append(sc)
         self.list_page.list.addItem("<new>")
         self.current_index = len(self.sub_components) - 1
@@ -1112,7 +1112,7 @@ class NewComplexWizard(QtWidgets.QDialog):
             return
         orig = self.sub_components[row]
         new_sc = SubComponent(
-            MacroInstance(orig.macro.name, orig.macro.params.copy()), orig.pins.copy()
+            MacroInstance(orig.macro.name, orig.macro.params.copy()), tuple(orig.pins)
         )
         self.sub_components.append(new_sc)
         self.list_page.list.addItem("<dup>")
@@ -1184,7 +1184,7 @@ class NewComplexWizard(QtWidgets.QDialog):
         pins = self.macro_page.checked_pins()
         sc = self.sub_components[self.current_index]
         sc.macro.name = macro.name
-        sc.pins = pins
+        sc.pins = tuple(pins)
         macros = getattr(sc, "_pins_s_macros", getattr(sc, "all_macros", {}))
         if isinstance(macros, dict):
             sc.macro.params = dict(macros.get(sc.macro.name, {}))

--- a/tests/test_edit_existing_complex_flow.py
+++ b/tests/test_edit_existing_complex_flow.py
@@ -70,7 +70,7 @@ class DummyWizard:
             mi = MacroInstance(sc.get("macro_name", ""), {})
             if sc.get("id_function") is not None:
                 mi.id_function = sc.get("id_function")
-            self.sub_components.append(SubComponent(mi, list(sc.get("pins") or [])))
+            self.sub_components.append(SubComponent(mi, tuple(sc.get("pins") or [])))
 
     @classmethod
     def from_existing(cls, prefill, complex_id, parent=None):
@@ -79,7 +79,9 @@ class DummyWizard:
     def exec(self):
         # simulate user changing first pin
         if self.sub_components and self.sub_components[0].pins:
-            self.sub_components[0].pins[0] = 5
+            pins = list(self.sub_components[0].pins)
+            pins[0] = 5
+            self.sub_components[0].pins = tuple(pins)
         return QtWidgets.QDialog.DialogCode.Accepted
 
 

--- a/tests/test_subcomponent_pins_immutable.py
+++ b/tests/test_subcomponent_pins_immutable.py
@@ -1,0 +1,7 @@
+from complex_editor.domain import MacroInstance, SubComponent
+import pytest
+
+def test_subcomponent_pins_are_immutable():
+    sc = SubComponent(MacroInstance("GATE", {}), [1, 2])
+    with pytest.raises(TypeError):
+        sc.pins[0] = 3

--- a/tests/test_wizard_flow.py
+++ b/tests/test_wizard_flow.py
@@ -56,6 +56,6 @@ def test_wizard_flow(qtbot):
     wizard.review_page.save_btn.click()
 
     assert len(wizard.sub_components) == 2
-    assert wizard.sub_components[0].pins == [1, 2]
-    assert wizard.sub_components[1].pins == [3, 4]
+    assert wizard.sub_components[0].pins == (1, 2)
+    assert wizard.sub_components[1].pins == (3, 4)
     assert wizard.sub_components[0].macro.params == wizard.sub_components[1].macro.params

--- a/tests/ui/test_complex_editor_new_flow.py
+++ b/tests/ui/test_complex_editor_new_flow.py
@@ -32,4 +32,4 @@ def test_complex_editor_new_flow(qtbot, monkeypatch):
     editor._on_accept()
     dev = editor.build_device()
     assert dev.pn == "CX1"
-    assert dev.subcomponents and dev.subcomponents[0].pins[:2] == [1, 2]
+    assert dev.subcomponents and dev.subcomponents[0].pins[:2] == (1, 2)


### PR DESCRIPTION
## Summary
- Store SubComponent pins as immutable tuples
- Update editor and wizard flows to handle tuple-based pins
- Add regression test for pin immutability

## Testing
- `pytest tests/test_subcomponent_pins_immutable.py -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68aae792e30c832cac606c7fcd45a87a