### PR TITLE
Allow pin edits with temporary duplicates

### DIFF
--- a/src/complex_editor/ui/complex_editor.py
+++ b/src/complex_editor/ui/complex_editor.py
@@ -220,12 +220,8 @@ class PinSpinDelegate(QtWidgets.QStyledItemDelegate):
 
     def setModelData(self, editor, model, index):  # pragma: no cover - UI
         value = int(editor.value())
-        row = index.row()
-        col = index.column() - 2
-        pins = list(self._model.rows[row].pins)
-        pins[col] = value
-        ok, _ = validate_pins(pins, self._pin_spin.value())
-        if not ok:
+        # only enforce basic range checks during inline edits
+        if value < 1 or value > self._pin_spin.value():
             QtWidgets.QApplication.beep()
             return
         model.setData(index, value, QtCore.Qt.ItemDataRole.EditRole)

--- a/tests/ui/test_pin_duplicate_edit.py
+++ b/tests/ui/test_pin_duplicate_edit.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src")))
+
+from PyQt6 import QtWidgets
+from complex_editor.ui.complex_editor import ComplexEditor
+from complex_editor.domain import MacroDef, MacroParam
+
+
+def _macro_map():
+    return {1: MacroDef(1, "M", [MacroParam("P", "INT", None, "0", "10")])}
+
+
+def test_pin_delegate_allows_duplicates(qtbot):
+    editor = ComplexEditor(_macro_map())
+    qtbot.addWidget(editor)
+    editor.pin_spin.setValue(3)
+    row = editor.model.add_row()
+    # prepare pins with a duplicate candidate
+    editor.model.rows[row].pins = [1, 2, 0, 0]
+    delegate = editor.table.itemDelegateForColumn(2)
+    spin = QtWidgets.QSpinBox()
+    spin.setValue(2)
+    delegate.setModelData(spin, editor.model, editor.model.index(row, 2))
+    assert editor.model.rows[row].pins[0] == 2


### PR DESCRIPTION
## Summary
- Permit pin edits in the Complex Editor even when duplicate pins exist temporarily
- Add regression test verifying delegate accepts duplicate pins

## Testing
- `pytest tests/ui/test_pin_duplicate_edit.py`
- `pytest` *(fails: assert 10 == 100, AttributeError: 'ComplexEditor' object has no attribute 'pin_table', assert None is not None)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1aa946a4832c8631761b7056fa64