### PR TITLE
Fix editor pin delegates and persistence

### DIFF
--- a/src/complex_editor/ui/complex_editor.py
+++ b/src/complex_editor/ui/complex_editor.py
@@ -179,33 +179,17 @@ class ComplexSubComponentsModel(QtCore.QAbstractTableModel):
 
 
 class MacroComboDelegate(QtWidgets.QStyledItemDelegate):
-    """Combo-box delegate for selecting macros."""
+    """Combo-box delegate for selecting macros (no pin logic)."""
 
     def __init__(self, macro_map: Dict[int, MacroDef], parent=None) -> None:
         super().__init__(parent)
         self._map = macro_map
 
     def createEditor(self, parent, option, index):  # pragma: no cover - UI
-        spin = QtWidgets.QSpinBox(parent)
-        spin.setMinimum(1)
-        spin.setMaximum(self._pin_spin.value())
-        spin.setButtonSymbols(QtWidgets.QAbstractSpinBox.ButtonSymbols.NoButtons)
-
-        # Ensure text is committed on Enter / focus out
-        spin.editingFinished.connect(lambda: self.commitData.emit(spin))
-        spin.editingFinished.connect(lambda: self.closeEditor.emit(spin))
-
-        # Keep the editor's max in sync if "Number of pins" changes while editing
-        try:
-            self._pin_spin.valueChanged.connect(spin.setMaximum)
-        except Exception:
-            # if already connected in repeated calls, ignore
-            pass
-
-        # Optional: prevents half-typed values from changing the spinbox mid-typing
-        spin.setKeyboardTracking(False)
-        return spin
-
+        combo = QtWidgets.QComboBox(parent)
+        for mid, macro in sorted(self._map.items()):
+            combo.addItem(macro.name, mid)
+        return combo
 
     def setEditorData(self, editor, index):  # pragma: no cover - UI
         row = index.model().rows[index.row()]
@@ -215,37 +199,7 @@ class MacroComboDelegate(QtWidgets.QStyledItemDelegate):
                 editor.setCurrentIndex(i)
 
     def setModelData(self, editor, model, index):  # pragma: no cover - UI
-        # Ensure typed text is parsed
-        try:
-            editor.interpretText()
-        except Exception:
-            pass
-
-        new_val = int(editor.value())
-        row = index.row()
-        col = index.column() - 2  # A=0, B=1, C=2, D=3 within the row model
-        max_pin = self._pin_spin.value()
-
-        # Range check only; we will handle duplicates by swapping
-        if new_val < 1 or new_val > max_pin:
-            QtWidgets.QApplication.beep()
-            return
-
-        pins = self._model.rows[row].pins
-        old_val = pins[col]
-
-        if new_val == old_val:
-            # Nothing to do
-            return
-
-        # If the new pin already exists in this row, SWAP instead of rejecting
-        if new_val in pins:
-            other_col = pins.index(new_val)  # 0..3 in row space
-            # Put the old value where the duplicate lived
-            model.setData(model.index(row, other_col + 2), old_val, QtCore.Qt.ItemDataRole.EditRole)
-
-        # Now set the edited cell to the new value
-        model.setData(index, new_val, QtCore.Qt.ItemDataRole.EditRole)
+        model.setData(index, editor.currentData(), QtCore.Qt.ItemDataRole.EditRole)
 
 
 
@@ -262,18 +216,13 @@ class PinSpinDelegate(QtWidgets.QStyledItemDelegate):
         spin = QtWidgets.QSpinBox(parent)
         spin.setMinimum(1)
         spin.setMaximum(self._pin_spin.value())
-        # Hide arrows so numbers are fully visible
         spin.setButtonSymbols(QtWidgets.QAbstractSpinBox.ButtonSymbols.NoButtons)
-        # Important: let the view own commit/close; don't emit commitData/closeEditor yourself
-        spin.setKeyboardTracking(False)  # only commit on Enter/focus-out
-        # Keep max in sync with "Number of pins"
+        spin.setKeyboardTracking(False)
         try:
             self._pin_spin.valueChanged.connect(spin.setMaximum)
         except Exception:
             pass
         return spin
-
-
 
     def setEditorData(self, editor, index):  # pragma: no cover - UI
         val = self._model.rows[index.row()].pins[index.column() - 2]
@@ -281,7 +230,6 @@ class PinSpinDelegate(QtWidgets.QStyledItemDelegate):
             editor.setValue(val)
 
     def setModelData(self, editor, model, index):  # pragma: no cover - UI
-        # Make sure typed text is parsed
         try:
             editor.interpretText()
         except Exception:
@@ -289,26 +237,13 @@ class PinSpinDelegate(QtWidgets.QStyledItemDelegate):
 
         new_val = int(editor.value())
         row = index.row()
-        col = index.column() - 2  # columns 2..5 map to pins A..D
-        max_pin = self._pin_spin.value()
-
-        # Range check only; duplicates are handled by swapping
-        if new_val < 1 or new_val > max_pin:
+        col = index.column() - 2
+        pins = list(self._model.rows[row].pins)
+        pins[col] = new_val
+        ok, _ = validate_pins(pins, self._pin_spin.value())
+        if not ok:
             QtWidgets.QApplication.beep()
             return
-
-        pins = self._model.rows[row].pins
-        old_val = pins[col]
-        if new_val == old_val:
-            return
-
-        # If new value exists elsewhere in the same row -> swap
-        if new_val in pins:
-            other_col = pins.index(new_val)
-            # move old value into the other slot
-            model.setData(model.index(row, other_col + 2), old_val, QtCore.Qt.ItemDataRole.EditRole)
-
-        # Set edited cell
         model.setData(index, new_val, QtCore.Qt.ItemDataRole.EditRole)
 
 
@@ -354,12 +289,12 @@ class ComplexEditor(QtWidgets.QDialog):
         )
         layout.addWidget(self.table)
 
-        # delegates for combo-box and pin selection
+        # delegates for combo-box and pin selection (keep references to avoid GC)
         self._macro_delegate = MacroComboDelegate(macro_map, self.table)
         self.table.setItemDelegateForColumn(1, self._macro_delegate)
-        pin_delegate = PinSpinDelegate(self.pin_spin, self.model, self.table)
+        self._pin_delegate = PinSpinDelegate(self.pin_spin, self.model, self.table)
         for col in range(2, 6):
-            self.table.setItemDelegateForColumn(col, pin_delegate)
+            self.table.setItemDelegateForColumn(col, self._pin_delegate)
         self.table.clicked.connect(self._table_clicked)
 
         btn_bar = QtWidgets.QHBoxLayout()
@@ -403,6 +338,7 @@ class ComplexEditor(QtWidgets.QDialog):
     def _remove_row(self) -> None:
         row = self.table.currentIndex().row()
         self.model.remove_row(row)
+        self._update_state()
 
     def _dup_row(self) -> None:
         # Ensure any in-progress edits are committed before duplicating

--- a/src/complex_editor/ui/main_window.py
+++ b/src/complex_editor/ui/main_window.py
@@ -137,87 +137,86 @@ class MainWindow(QtWidgets.QMainWindow):
             result[key] = str(v)
         return result
 
-    def _persist_editor_device(self, updated_dev):
-        """Persist ComplexEditor result to buffer.json (if buffer mode) or MDB."""
+    def _persist_editor_device(self, updated_ui_dev: ComplexDevice, comp_id: int | None):
+        """Persist ComplexEditor result to buffer or MDB, enforcing type safety."""
 
-        # Build DB subcomponents and PinS
-        def _to_db_subs(dev):
-            subs = []
-            for sc in dev.subcomponents:
-                fid = self._macro_id_from_name(sc.macro.name) or 0
-                pins = {k: v for k, v in zip(["A", "B", "C", "D"], sc.pins)}
-                xml = params_to_xml(
-                    {sc.macro.name: sc.macro.params},
-                    encoding="utf-16",
-                    schema=ALLOWED_PARAMS,
-                ).decode("utf-16")
-                pins["S"] = xml
-                subs.append(DbSub(None, fid, pins=pins))
-            return subs
+        subs: List[DbSub] = []
+        for sc in updated_ui_dev.subcomponents:
+            fid = self._macro_id_from_name(sc.macro.name) or 0
+            pins = {
+                "A": sc.pins[0] if sc.pins[0] > 0 else None,
+                "B": sc.pins[1] if sc.pins[1] > 0 else None,
+                "C": sc.pins[2] if sc.pins[2] > 0 else None,
+                "D": sc.pins[3] if sc.pins[3] > 0 else None,
+            }
+            xml = params_to_xml(
+                {sc.macro.name: sc.macro.params},
+                encoding="utf-16",
+                schema=ALLOWED_PARAMS,
+            )
+            xml_str = xml.decode("utf-16") if isinstance(xml, (bytes, bytearray)) else str(xml)
+            pins["S"] = xml_str
+            subs.append(DbSub(None, int(fid), pins=pins))
 
-        # Buffer mode: write raw JSON
+        db_dev = DbComplex(comp_id, updated_ui_dev.pn, int(updated_ui_dev.pin_count), subs)
+
         if (
             self._buffer_complexes is not None
             and self._buffer_raw is not None
             and self._buffer_path is not None
         ):
             row = self.list.currentRow()
-            raw = self._buffer_raw[row]
-            raw["name"] = updated_dev.pn
-            if updated_dev.alt_pn:
-                raw["alt_pn"] = updated_dev.alt_pn
-            raw["pins"] = [str(i) for i in range(1, updated_dev.pin_count + 1)]
-            subs_raw = []
-            for sc in updated_dev.subcomponents:
-                xml = params_to_xml(
-                    {sc.macro.name: sc.macro.params},
-                    encoding="utf-16",
-                    schema=ALLOWED_PARAMS,
-                ).decode("utf-16")
-                subs_raw.append(
-                    {
-                        "function_name": sc.macro.name,
-                        "pins": {
-                            "A": sc.pins[0],
-                            "B": sc.pins[1],
-                            "C": sc.pins[2],
-                            "D": sc.pins[3],
-                            "S": xml,
-                        },
-                    }
+            if row < 0 or row >= len(self._buffer_raw):
+                row = len(self._buffer_raw)
+                self._buffer_raw.append({})
+                self._buffer_complexes.append(
+                    EditorComplex(comp_id or 0, "", [], [])
                 )
-            raw["subcomponents"] = subs_raw
+            raw = self._buffer_raw[row]
+            raw["name"] = updated_ui_dev.pn
+            if updated_ui_dev.alt_pn:
+                raw["alt_pn"] = updated_ui_dev.alt_pn
+            raw["pins"] = [str(i) for i in range(1, updated_ui_dev.pin_count + 1)]
+            raw["subcomponents"] = [
+                {
+                    "function_name": sc.macro.name,
+                    "pins": {
+                        "A": s.pins["A"],
+                        "B": s.pins["B"],
+                        "C": s.pins["C"],
+                        "D": s.pins["D"],
+                        "S": s.pins["S"],
+                    },
+                }
+                for s, sc in zip(subs, updated_ui_dev.subcomponents)
+            ]
             save_buffer(self._buffer_path, self._buffer_raw)
 
-            if 0 <= row < len(self._buffer_complexes):
-                cx = self._buffer_complexes[row]
-                cx.name = updated_dev.pn
-                cx.pins = [str(i) for i in range(1, updated_dev.pin_count + 1)]
-                cx.subcomponents = [
-                    EditorMacro(
-                        sc.macro.name,
-                        {
-                            "A": str(sc.pins[0]),
-                            "B": str(sc.pins[1]),
-                            "C": str(sc.pins[2]),
-                            "D": str(sc.pins[3]),
-                        },
-                        sc.macro.params,
-                    )
-                    for sc in updated_dev.subcomponents
-                ]
-            return
-
-        # MDB mode: create/update Complex in DB
-        if self.db is not None:
-            cid = updated_dev.id
-            subs = _to_db_subs(updated_dev)
-            db_dev = DbComplex(cid, updated_dev.pn, updated_dev.pin_count, subs)
-            if cid is None:
+            cx = self._buffer_complexes[row]
+            cx.name = updated_ui_dev.pn
+            cx.pins = [str(i) for i in range(1, updated_ui_dev.pin_count + 1)]
+            cx.subcomponents = [
+                EditorMacro(
+                    sc.macro.name,
+                    {
+                        "A": str(sc.pins[0]),
+                        "B": str(sc.pins[1]),
+                        "C": str(sc.pins[2]),
+                        "D": str(sc.pins[3]),
+                    },
+                    sc.macro.params,
+                )
+                for sc in updated_ui_dev.subcomponents
+            ]
+        else:
+            assert self.db is not None
+            if comp_id is None:
                 self.db.add_complex(db_dev)
             else:
-                self.db.update_complex(cid, updated=db_dev)
+                self.db.update_complex(comp_id, updated=db_dev)
             self.db._conn.commit()
+
+        self._refresh_list()
 
     def _refresh_list(self) -> None:
         if self._buffer_complexes is not None:
@@ -367,8 +366,7 @@ class MainWindow(QtWidgets.QMainWindow):
         editor = ComplexEditor(macro_map)
         if editor.exec() == QtWidgets.QDialog.DialogCode.Accepted:
             updated = editor.build_device()
-            self._persist_editor_device(updated)
-            self._refresh_list()
+            self._persist_editor_device(updated, comp_id=None)
 
 
     def _on_edit(self) -> None:
@@ -416,8 +414,7 @@ class MainWindow(QtWidgets.QMainWindow):
             editor.load_device(dev)
             if editor.exec() == QtWidgets.QDialog.DialogCode.Accepted:
                 updated = editor.build_device()
-                self._persist_editor_device(updated)
-                self._refresh_list()
+                self._persist_editor_device(updated, comp_id=cx.id)
                 self.list.selectRow(row)
                 self._on_selected()
             return
@@ -461,8 +458,7 @@ class MainWindow(QtWidgets.QMainWindow):
         editor.load_device(dev)
         if editor.exec() == QtWidgets.QDialog.DialogCode.Accepted:
             updated = editor.build_device()
-            self._persist_editor_device(updated)
-            self._refresh_list()
+            self._persist_editor_device(updated, comp_id=cid)
             self.list.selectRow(row)
             self._on_selected()
             QtWidgets.QMessageBox.information(self, "Updated", "Complex updated")


### PR DESCRIPTION
## Summary
- refactor ComplexEditor delegates to separate macro combo from pin editing and keep delegates alive
- validate and commit pin edits without arrows and revalidate after row changes
- persist editor updates safely to buffer or MDB, converting zero pins to NULL and ensuring string XML

## Testing
- `python -m py_compile src/complex_editor/ui/complex_editor.py src/complex_editor/ui/main_window.py src/complex_editor/ui/validators.py`
- `pytest` *(fails: assert mismatches and AttributeErrors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3834002c832cb9cb5d3b62f17bd2