### PR TITLE
Add CLI bridge control and shutdown support

### DIFF
--- a/src/ce_bridge_service/models.py
+++ b/src/ce_bridge_service/models.py
@@ -38,6 +38,9 @@ class HealthResponse(BaseModel):
     ok: bool
     version: str
     db_path: str
+    host: str
+    port: int
+    auth_required: bool
 
 
 __all__ = [

--- a/src/ce_bridge_service/run.py
+++ b/src/ce_bridge_service/run.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import subprocess
 import sys
+import time
 from pathlib import Path
+from typing import Any, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 import uvicorn
 
@@ -28,26 +34,72 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Override bearer token (warning: prints in plain text)",
     )
+    parser.add_argument(
+        "--start-bridge",
+        action="store_true",
+        help="Ensure the bridge service is running, starting it if necessary.",
+    )
+    parser.add_argument(
+        "--shutdown-bridge",
+        action="store_true",
+        help="Shutdown a running bridge service (requires matching bearer token).",
+    )
     return parser.parse_args(argv)
 
 
-def main(argv: list[str] | None = None) -> None:
-    args = _parse_args(argv)
+def _set_config_path(path: Path | None) -> None:
+    if path is not None:
+        os.environ[CONFIG_ENV_VAR] = str(Path(path).expanduser())
 
-    if args.config is not None:
-        os.environ[CONFIG_ENV_VAR] = str(Path(args.config).expanduser())
 
-    cfg = load_config()
-    bridge_cfg = cfg.bridge
+def _display_host(configured: str, probe_host: str) -> str:
+    if configured in {"0.0.0.0", "::"}:
+        return probe_host
+    return configured
 
-    if args.host:
-        bridge_cfg.host = args.host
-    if args.port:
-        bridge_cfg.port = int(args.port)
-        bridge_cfg.base_url = f"http://{bridge_cfg.host}:{bridge_cfg.port}"
-    if args.token is not None:
-        bridge_cfg.auth_token = args.token
 
+def _effective_probe_host(host: str) -> str:
+    host = host.strip() or "127.0.0.1"
+    if host in {"0.0.0.0", "::"}:
+        return "127.0.0.1"
+    return host
+
+
+def _probe_health(host: str, port: int, token: str | None, timeout: float = 1.0) -> Tuple[str, Any, str]:
+    probe_host = _effective_probe_host(host)
+    url = f"http://{probe_host}:{port}/health"
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(url, headers=headers)
+    try:
+        with urlopen(request, timeout=timeout) as response:  # nosec B310 - controlled URL
+            payload = response.read()
+    except HTTPError as exc:
+        if exc.code in (401, 403):
+            return "unauthorized", None, probe_host
+        return "other_service", exc, probe_host
+    except URLError as exc:
+        reason = exc.reason
+        if isinstance(reason, (ConnectionRefusedError, TimeoutError)):
+            return "not_running", None, probe_host
+        if isinstance(reason, OSError) and getattr(reason, "errno", None) in {61, 111, 10061}:
+            return "not_running", None, probe_host
+        return "other_service", exc, probe_host
+    except Exception as exc:  # pragma: no cover - defensive
+        return "other_service", exc, probe_host
+
+    try:
+        data = json.loads(payload.decode("utf-8"))
+    except Exception as exc:  # pragma: no cover - defensive
+        return "other_service", exc, probe_host
+
+    if isinstance(data, dict) and data.get("ok") is True:
+        return "running", data, probe_host
+    return "other_service", data, probe_host
+
+
+def _run_server(cfg, bridge_cfg) -> int:
     if not cfg.database.mdb_path.exists():
         raise SystemExit(f"Database not found at {cfg.database.mdb_path}")
 
@@ -55,6 +107,15 @@ def main(argv: list[str] | None = None) -> None:
         get_mdb_path=lambda: cfg.database.mdb_path,
         auth_token=bridge_cfg.auth_token or None,
         wizard_handler=None,
+        bridge_host=bridge_cfg.host,
+        bridge_port=int(bridge_cfg.port),
+    )
+
+    auth_mode = "enabled" if bridge_cfg.auth_token else "disabled"
+    print(
+        f"[ce-bridge] listening on http://{bridge_cfg.host}:{bridge_cfg.port} "
+        f"(auth: {auth_mode})",
+        flush=True,
     )
 
     config = uvicorn.Config(
@@ -62,13 +123,192 @@ def main(argv: list[str] | None = None) -> None:
         host=bridge_cfg.host,
         port=int(bridge_cfg.port),
         log_level="info",
+        timeout_graceful_shutdown=1,
     )
     server = uvicorn.Server(config)
+
+    def _trigger_shutdown() -> None:
+        server.should_exit = True
+
+    app.state.trigger_shutdown = _trigger_shutdown
     try:
         server.run()
     except KeyboardInterrupt:  # pragma: no cover - CLI convenience
         pass
+    return 0
+
+
+def _ensure_bridge(cfg, bridge_cfg) -> int:
+    if not cfg.database.mdb_path.exists():
+        raise SystemExit(f"Database not found at {cfg.database.mdb_path}")
+
+    token = bridge_cfg.auth_token or ""
+    port = int(bridge_cfg.port)
+    status, _, probe_host = _probe_health(bridge_cfg.host, port, token or None)
+
+    if status == "running":
+        auth_mode = "enabled" if token else "disabled"
+        print(
+            f"[ce-bridge] already running on http://{_display_host(bridge_cfg.host, probe_host)}:{port} "
+            f"(auth: {auth_mode})",
+            flush=True,
+        )
+        return 0
+    if status == "unauthorized":
+        raise SystemExit(
+            "Bridge is already running but the provided token was rejected."
+        )
+    if status == "other_service":
+        raise SystemExit(
+            f"Port {port} appears to be in use and did not respond like the CE bridge."
+        )
+
+    # not running, start new process
+    cmd = [
+        sys.executable,
+        "-m",
+        "ce_bridge_service.run",
+        "--host",
+        bridge_cfg.host,
+        "--port",
+        str(port),
+    ]
+    if token:
+        cmd.extend(["--token", token])
+
+    env = os.environ.copy()
+    process = subprocess.Popen(
+        cmd,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    deadline = time.monotonic() + 15.0
+    status: str = "not_running"
+    try:
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                raise SystemExit(
+                    f"Bridge process exited unexpectedly with code {process.returncode}"
+                )
+            status, _, _ = _probe_health(bridge_cfg.host, port, token or None)
+            if status == "running":
+                auth_mode = "enabled" if token else "disabled"
+                print(
+                    f"[ce-bridge] listening on http://{_display_host(bridge_cfg.host, probe_host)}:{port} "
+                    f"(auth: {auth_mode})",
+                    flush=True,
+                )
+                return 0
+            if status == "unauthorized":
+                raise SystemExit(
+                    "Bridge started but rejected the provided token."
+                )
+            if status == "other_service":
+                raise SystemExit(
+                    f"Port {port} became occupied by another service during startup."
+                )
+            time.sleep(0.2)
+    finally:
+        if process.poll() is None and status != "running":
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except Exception:  # pragma: no cover - defensive
+                try:
+                    process.kill()
+                except Exception:  # pragma: no cover - defensive
+                    pass
+
+    raise SystemExit("Timed out waiting for bridge health endpoint")
+
+
+def _shutdown_bridge(cfg, bridge_cfg) -> int:
+    if not cfg.database.mdb_path.exists():
+        raise SystemExit(f"Database not found at {cfg.database.mdb_path}")
+
+    token = bridge_cfg.auth_token or ""
+    port = int(bridge_cfg.port)
+    status, _, probe_host = _probe_health(bridge_cfg.host, port, token or None)
+
+    if status == "unauthorized":
+        raise SystemExit("Bridge rejected the provided token; cannot shutdown")
+    if status == "other_service":
+        raise SystemExit(
+            f"Port {port} is occupied by a different service; aborting shutdown."
+        )
+    if status == "not_running":
+        print(
+            f"[ce-bridge] no running instance on http://{_display_host(bridge_cfg.host, probe_host)}:{port}",
+            flush=True,
+        )
+        return 0
+
+    url = f"http://{probe_host}:{port}/admin/shutdown"
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = Request(url, data=b"{}", headers=headers, method="POST")
+    try:
+        with urlopen(request, timeout=3.0):  # nosec B310 - controlled URL
+            pass
+    except HTTPError as exc:
+        if exc.code in (401, 403):
+            raise SystemExit("Bridge rejected the provided token; cannot shutdown")
+        raise SystemExit(f"Failed to request shutdown: {exc}") from exc
+    except URLError as exc:
+        raise SystemExit(f"Failed to contact bridge for shutdown: {exc}") from exc
+
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        status, _, _ = _probe_health(bridge_cfg.host, port, token or None)
+        if status == "not_running":
+            print(
+                f"[ce-bridge] shutdown complete for http://{_display_host(bridge_cfg.host, probe_host)}:{port}",
+                flush=True,
+            )
+            return 0
+        if status == "other_service":
+            raise SystemExit(
+                f"Port {port} became occupied by a different service during shutdown."
+            )
+        time.sleep(0.2)
+
+    raise SystemExit("Timed out waiting for bridge to shutdown")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    if args.start_bridge and args.shutdown_bridge:
+        raise SystemExit("--start-bridge and --shutdown-bridge are mutually exclusive")
+
+    if args.port is not None and (args.port <= 0 or args.port > 65535):
+        raise SystemExit("Bridge port must be between 1 and 65535")
+
+    _set_config_path(args.config)
+
+    cfg = load_config()
+    bridge_cfg = cfg.bridge
+
+    if args.host:
+        bridge_cfg.host = args.host
+    if args.port is not None:
+        bridge_cfg.port = int(args.port)
+    if args.token is not None:
+        bridge_cfg.auth_token = args.token
+
+    bridge_cfg.base_url = f"http://{bridge_cfg.host}:{bridge_cfg.port}"
+
+    if args.start_bridge:
+        return _ensure_bridge(cfg, bridge_cfg)
+
+    if args.shutdown_bridge:
+        return _shutdown_bridge(cfg, bridge_cfg)
+
+    return _run_server(cfg, bridge_cfg)
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(sys.argv[1:])
+    sys.exit(main(sys.argv[1:]))

--- a/src/complex_editor/__main__.py
+++ b/src/complex_editor/__main__.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from . import __version__
+from .config.loader import CONFIG_ENV_VAR, load_config
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Complex Editor launcher")
+    parser.add_argument("--start-bridge", action="store_true", help="Ensure the HTTP bridge is running")
+    parser.add_argument("--shutdown-bridge", action="store_true", help="Shutdown a running HTTP bridge")
+    parser.add_argument("--port", type=int, default=None, help="Override bridge port for this run")
+    parser.add_argument("--token", type=str, default=None, help="Override bridge bearer token for this run")
+    parser.add_argument("--config", type=Path, default=None, help="Path to configuration file")
+    parser.add_argument("--buffer", type=Path, default=None, help="Open the GUI against a buffer JSON file")
+    parser.add_argument("--load-buffer", type=Path, default=None, help="Preview a buffer JSON in the wizard")
+    parser.add_argument("--version", action="version", version=__version__)
+    return parser.parse_args(argv)
+
+
+def _forward_bridge_args(args: argparse.Namespace) -> list[str]:
+    forwarded: list[str] = []
+    if args.config is not None:
+        forwarded.extend(["--config", str(Path(args.config).expanduser())])
+    if args.port is not None:
+        forwarded.extend(["--port", str(int(args.port))])
+    if args.token is not None:
+        forwarded.extend(["--token", args.token])
+    if args.start_bridge:
+        forwarded.append("--start-bridge")
+    if args.shutdown_bridge:
+        forwarded.append("--shutdown-bridge")
+    return forwarded
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    if args.start_bridge and args.shutdown_bridge:
+        raise SystemExit("--start-bridge and --shutdown-bridge cannot be used together")
+
+    if args.port is not None and (args.port <= 0 or args.port > 65535):
+        raise SystemExit("Bridge port must be between 1 and 65535")
+
+    if args.config is not None:
+        os.environ[CONFIG_ENV_VAR] = str(Path(args.config).expanduser())
+
+    if args.start_bridge or args.shutdown_bridge:
+        # Load configuration to surface validation errors early before delegating.
+        load_config()
+        from ce_bridge_service import run as bridge_run
+
+        forwarded = _forward_bridge_args(args)
+        return bridge_run.main(forwarded)
+
+    if args.load_buffer is not None and args.buffer is not None:
+        raise SystemExit("--buffer and --load-buffer are mutually exclusive")
+
+    if args.load_buffer is not None:
+        from PyQt6 import QtWidgets  # type: ignore
+        from .io.buffer_loader import load_complex_from_buffer_json, to_wizard_prefill
+        from .ui.new_complex_wizard import NewComplexWizard
+
+        app = QtWidgets.QApplication(sys.argv)
+        buf = load_complex_from_buffer_json(args.load_buffer)
+        prefill = to_wizard_prefill(buf, lambda name: None, lambda m: m)
+        wiz = NewComplexWizard.from_wizard_prefill(prefill)
+        wiz.show()
+        sys.exit(app.exec())
+
+    from .ui.main_window import run_gui
+
+    if args.buffer is not None:
+        run_gui(mdb_file=None, buffer_path=args.buffer)
+    else:
+        run_gui()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))

--- a/src/complex_editor/ui/bridge_controller.py
+++ b/src/complex_editor/ui/bridge_controller.py
@@ -80,6 +80,8 @@ class BridgeController:
                 wizard_handler=lambda pn, aliases: self._invoker.invoke(
                     wizard_handler, pn, aliases
                 ),
+                bridge_host=config.host,
+                bridge_port=int(config.port),
             )
             app.add_event_handler("startup", self._ready_event.set)
             app.add_event_handler("shutdown", self._ready_event.clear)

--- a/tests/test_complex_editor_entry.py
+++ b/tests/test_complex_editor_entry.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = ROOT / "src"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _run_module(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, "-m", "complex_editor", *args]
+    return subprocess.run(cmd, check=False, text=True, env=env)
+
+
+def _wait_for_health(port: int, token: str, timeout: float = 10.0) -> dict:
+    deadline = time.monotonic() + timeout
+    url = f"http://127.0.0.1:{port}/health"
+    headers = {"Authorization": f"Bearer {token}"}
+    while time.monotonic() < deadline:
+        request = Request(url, headers=headers)
+        try:
+            with urlopen(request, timeout=1.0) as response:  # nosec B310 - controlled URL
+                payload = response.read()
+        except (URLError, ConnectionError):  # pragma: no cover - network error variations
+            time.sleep(0.2)
+            continue
+        except HTTPError as exc:
+            if exc.code in (401, 403):
+                raise AssertionError("Bridge rejected token during health probe") from exc
+            time.sleep(0.2)
+            continue
+        data = json.loads(payload.decode("utf-8"))
+        if data.get("ok"):
+            return data
+        time.sleep(0.2)
+    raise AssertionError("Bridge health endpoint did not become ready in time")
+
+
+def _wait_for_shutdown(port: int, token: str, timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    url = f"http://127.0.0.1:{port}/health"
+    headers = {"Authorization": f"Bearer {token}"}
+    while time.monotonic() < deadline:
+        request = Request(url, headers=headers)
+        try:
+            with urlopen(request, timeout=1.0):  # nosec B310 - controlled URL
+                pass
+        except URLError:
+            return
+        except HTTPError:
+            time.sleep(0.2)
+            continue
+        time.sleep(0.2)
+    raise AssertionError("Bridge did not shutdown in time")
+
+
+def test_complex_editor_module_controls_bridge(tmp_path: Path) -> None:
+    port = _free_port()
+    token = "test-token"
+
+    mdb_path = tmp_path / "dummy.mdb"
+    mdb_path.touch()
+
+    config_path = tmp_path / "ce.yml"
+    config_payload = {
+        "database": {"mdb_path": str(mdb_path)},
+        "bridge": {"host": "127.0.0.1"},
+    }
+    config_path.write_text(yaml.safe_dump(config_payload, sort_keys=False), encoding="utf-8")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(SRC_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    env.setdefault("QT_QPA_PLATFORM", "offscreen")
+    env["CE_CONFIG"] = str(config_path)
+
+    start_args = [
+        "--start-bridge",
+        "--port",
+        str(port),
+        "--token",
+        token,
+        "--config",
+        str(config_path),
+    ]
+
+    start_proc = _run_module(start_args, env)
+    if start_proc.returncode != 0:
+        raise AssertionError(start_proc.stderr or start_proc.stdout)
+
+    try:
+        health = _wait_for_health(port, token)
+    except AssertionError as exc:  # pragma: no cover - diagnostic aid
+        raise AssertionError(
+            f"{exc}\nstdout:\n{start_proc.stdout or ''}\nstderr:\n{start_proc.stderr or ''}"
+        ) from exc
+    assert health["ok"] is True
+    assert health["port"] == port
+    assert health["auth_required"] is True
+
+    reuse_proc = _run_module(start_args, env)
+    if reuse_proc.returncode != 0:
+        raise AssertionError(reuse_proc.stderr or reuse_proc.stdout)
+
+    shutdown_args = [
+        "--shutdown-bridge",
+        "--port",
+        str(port),
+        "--token",
+        token,
+        "--config",
+        str(config_path),
+    ]
+
+    try:
+        stop_proc = _run_module(shutdown_args, env)
+        if stop_proc.returncode != 0:
+            raise AssertionError(stop_proc.stderr or stop_proc.stdout)
+    finally:
+        _wait_for_shutdown(port, token)


### PR DESCRIPTION
## Summary
- add a Complex Editor CLI entry point that routes bridge start/shutdown flags and otherwise launches the GUI
- enhance the bridge runner to detach background servers, log reuse, and implement authenticated `/admin/shutdown`
- extend the FastAPI app and tests to cover the shutdown endpoint and a `python -m complex_editor` integration flow

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 QT_QPA_PLATFORM=offscreen PYTHONPATH=src pytest tests/test_bridge_service.py tests/test_complex_editor_entry.py

------
https://chatgpt.com/codex/tasks/task_e_68e351a3b99c832c8bc216be18aa8841