### PR TITLE
Fix Access database warning string literal and add PyInstaller build script

### DIFF
--- a/build_exe.sh
+++ b/build_exe.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_NAME="ComplexEditor"
+DIST_DIR="$PROJECT_ROOT/dist"
+BUILD_DIR="$PROJECT_ROOT/build"
+SPEC_FILE="$PROJECT_ROOT/${APP_NAME}.spec"
+PYTHON_BIN="${PYTHON:-python}"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "error: python interpreter '$PYTHON_BIN' not found" >&2
+  exit 1
+fi
+
+if ! "$PYTHON_BIN" -c "import PyInstaller" >/dev/null 2>&1; then
+  echo "PyInstaller not found. Installing into the current environment..." >&2
+  "$PYTHON_BIN" -m pip install --upgrade pip
+  "$PYTHON_BIN" -m pip install pyinstaller
+fi
+
+cd "$PROJECT_ROOT"
+
+rm -rf "$BUILD_DIR" "$DIST_DIR"
+rm -f "$SPEC_FILE"
+
+case "${OSTYPE:-}" in
+  msys*|cygwin*|win32*)
+    DATA_SEP=';'
+    EXEC_SUFFIX='.exe'
+    ;;
+  *)
+    DATA_SEP=':'
+    EXEC_SUFFIX=''
+    ;;
+esac
+
+RESOURCE_DATA="src/complex_editor/resources${DATA_SEP}complex_editor/resources"
+ASSET_DATA="src/complex_editor/assets${DATA_SEP}complex_editor/assets"
+
+"$PYTHON_BIN" -m PyInstaller \
+  --noconfirm \
+  --clean \
+  --windowed \
+  --name "$APP_NAME" \
+  --collect-submodules complex_editor \
+  --add-data "$RESOURCE_DATA" \
+  --add-data "$ASSET_DATA" \
+  src/complex_editor/__main__.py
+
+OUTPUT_PATH="$DIST_DIR/$APP_NAME$EXEC_SUFFIX"
+
+echo "Build complete: $OUTPUT_PATH"

--- a/src/complex_editor/ui/main_window.py
+++ b/src/complex_editor/ui/main_window.py
@@ -734,8 +734,7 @@ def _ensure_database_available(ctx: AppContext, parent: QtWidgets.QWidget | None
         msg.setIcon(QtWidgets.QMessageBox.Icon.Warning)
         msg.setWindowTitle("Access Database Required")
         msg.setText(
-            "The configured Access database could not be found.
-"
+            "The configured Access database could not be found.\n"
             "Select an existing file or create a new database from the template."
         )
         select_btn = msg.addButton("Select Existing...", QtWidgets.QMessageBox.ButtonRole.AcceptRole)


### PR DESCRIPTION
## Summary
- correct the warning message text shown when the Access database is missing to ensure the string literal is terminated properly
- include an explicit newline between the sentences in the dialog text
- add a `build_exe.sh` helper that runs PyInstaller with the required resources to create a standalone executable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e35d7db444832c927b0700222c94e4