### PR TITLE
Fix package initialization for frozen __main__ entry point

### DIFF
--- a/src/complex_editor/__main__.py
+++ b/src/complex_editor/__main__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 if __package__ in (None, ""):
     PACKAGE_ROOT = Path(__file__).resolve().parent
     sys.path.insert(0, str(PACKAGE_ROOT.parent))
+    __package__ = "complex_editor"
 
     from complex_editor import __version__  # type: ignore
     from complex_editor.config.loader import CONFIG_ENV_VAR, load_config  # type: ignore


### PR DESCRIPTION
## Summary
- ensure the complex_editor __main__ module assigns its package name when run as a script so relative imports succeed in frozen builds

## Testing
- pytest *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f341ff24832c9cf854180b652bc4